### PR TITLE
Shrink the docker image by cleaning cache and temporary files.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,9 @@ language: sh
 services:
   - docker
 
-env:
-  DOCKER_COMPOSE_VERSION: 1.4.2
-
 before_install:
-  - sudo rm /usr/local/bin/docker-compose
-  - curl -L https://github.com/docker/compose/releases/download/${DOCKER_COMPOSE_VERSION}/docker-compose-`uname -s`-`uname -m` > docker-compose
-  - chmod +x docker-compose
-  - sudo mv docker-compose /usr/local/bin
-  - sudo apt-get install -y python-virtualenv curl
+  - sudo apt-get update
+  - sudo apt-get -y -o Dpkg::Options::="--force-confnew" install docker-engine
 
 script:
   - bash ./.travistest.sh

--- a/.travistest.sh
+++ b/.travistest.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 set -eux
+docker version
+docker-compose version
 make get-sample
 make build-image
 tests/test-generic.sh tests/docker-compose-postgres.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,7 @@
 # Mendix Deployment Archive (aka mda file)
 #
 # Author: Mendix Digital Ecosystems, digitalecosystems@mendix.com
-# Version: 1.1
-
+# Version: 1.2
 FROM ubuntu:trusty
 MAINTAINER Mendix Digital Ecosystems <digitalecosystems@mendix.com>
 
@@ -32,7 +31,8 @@ COPY $BUILD_PATH build
 
 # Compile the application source code
 WORKDIR /buildpack
-RUN "/buildpack/compilation" /build /cache
+RUN "/buildpack/compilation" /build /cache && \
+  rm -fr /cache /tmp/javasdk /tmp/opt
 
 # Expose nginx port
 ENV PORT 80

--- a/Dockerfile
+++ b/Dockerfile
@@ -29,7 +29,7 @@ ENV PYTHONPATH "/buildpack/lib/"
 RUN mkdir build cache
 COPY $BUILD_PATH build
 
-# Compile the application source code
+# Compile the application source code and remove temp files
 WORKDIR /buildpack
 RUN "/buildpack/compilation" /build /cache && \
   rm -fr /cache /tmp/javasdk /tmp/opt

--- a/Makefile
+++ b/Makefile
@@ -4,13 +4,17 @@ get-sample:
 	mkdir -p downloads build
 	wget https://cdn.mendix.com/sample/SampleAppA.mpk -O downloads/application.mpk
 	unzip downloads/application.mpk -d build/
+
 build-image:
 	docker build \
 	--build-arg BUILD_PATH=build \
 	-t mendix/mendix-buildpack:v1 .
+
 test-container:
 	tests/test-generic.sh tests/docker-compose-postgres.yml
 	tests/test-generic.sh tests/docker-compose-sqlserver.yml
 	tests/test-generic.sh tests/docker-compose-azuresql.yml
-run-test-container:
-	docker-compose -f tests/docker-compose-postgres.yml
+
+run-container:
+	docker-compose -f tests/docker-compose-postgres.yml up
+

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ get-sample:
 build-image:
 	docker build \
 	--build-arg BUILD_PATH=build \
-	-t mendix/mendix-buildpack:v1 .
+	-t mendix/mendix-buildpack:v1.2 .
 
 test-container:
 	tests/test-generic.sh tests/docker-compose-postgres.yml
@@ -17,4 +17,3 @@ test-container:
 
 run-container:
 	docker-compose -f tests/docker-compose-postgres.yml up
-

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ Before running the container, it is necessary to build the image with your appli
 
 ```
 docker build --build-arg BUILD_PATH=<mendix-project-location> \
-	-t mendix/mendix-buildpack:v1 .
+	-t mendix/mendix-buildpack:v1.2 .
 ```
 
 ### Startup
@@ -56,7 +56,7 @@ and the **DATABASE_ENDPOINT** as you can see in the example below:
 docker run -it \
   -e ADMIN_PASSWORD=Password1! \
   -e DATABASE_ENDPOINT=postgres://username:password@host:port/mendix \
-  mendix/mendix-buildpack:v1  
+  mendix/mendix-buildpack:v1.2  
 ```
 
 or for Microsoft SQL server
@@ -65,7 +65,7 @@ or for Microsoft SQL server
 docker run -it \
   -e ADMIN_PASSWORD=Password1! \
   -e DATABASE_ENDPOINT=sqlserver://username:password@host:port/mendix \
-  mendix/mendix-buildpack:v1  
+  mendix/mendix-buildpack:v1.2  
 ```
 
 ## Features
@@ -98,7 +98,7 @@ docker run -it \
   -e DATABASE_ENDPOINT=postgres://mendix:mendix@172.17.0.2:5432/mendix \
   -e LICENSE_ID=<UUID> \
   -e LICENSE_KEY=<LICENSE_KEY> \
-  mendix/mendix-buildpack:v1  
+  mendix/mendix-buildpack:v1.2  
 ```
 
 ### Passing environment variables to your Mendix runtine
@@ -115,7 +115,7 @@ docker run -it \
   -e MX_Module_Constant=ABC123 \
   -e LICENSE_ID=<UUID> \
   -e LICENSE_KEY=<LICENSE_KEY> \
-  mendix/mendix-buildpack:v1  
+  mendix/mendix-buildpack:v1.2  
 ```
 
 ### Configuring Custom Runtime Settings
@@ -132,7 +132,7 @@ docker run -it \
   -e ADMIN_PASSWORD=Password1! \
   -e DATABASE_ENDPOINT=postgres://mendix:mendix@172.17.0.2:5432/mendix \
   -e MXRUNTIME_ConnectionPoolingMinIdle 10 \
-  mendix/mendix-buildpack:v1  
+  mendix/mendix-buildpack:v1.2  
 ```
 
 If the setting contains a dot . you can use an underscore _ in the environment variable. So to set com.mendix.storage.s3.EndPoint to foo you can use:
@@ -155,7 +155,7 @@ docker run -it \
   -e ADMIN_PASSWORD=Password1! \
   -e DATABASE_ENDPOINT=postgres://mendix:mendix@172.17.0.2:5432/mendix \
   -e SCHEDULED_EVENTS=ALL \
-  mendix/mendix-buildpack:v1  
+  mendix/mendix-buildpack:v1.2  
 ```
 
 ### Configuring Application log levels
@@ -184,7 +184,7 @@ docker run -it \
   -e ADMIN_PASSWORD=Password1! \
   -e DATABASE_ENDPOINT=postgres://mendix:mendix@172.17.0.2:5432/mendix \
   -e LOGGING_CONFIG='{"Core": "DEBUG"}' \
-  mendix/mendix-buildpack:v1  
+  mendix/mendix-buildpack:v1.2  
 ```
 
 ## Contributions

--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ The Mendix Buildpack for Docker (aka docker-mendix-buildpack) provides a standar
 ## Try a sample mendix application
 
 Open a terminal and run the following code
+
 ```
 git clone https://github.com/mendix/docker-mendix-buildpack
 cd docker-mendix-buildpack
@@ -17,7 +18,7 @@ make build-image
 make run-container
 ```
 
-You can now open you browser http://localhost:8080
+You can now open you browser [http://localhost:8080]([http://localhost:8080])
 
 ## Uses cases scenarios:
 
@@ -31,6 +32,7 @@ This project is goto reference for the following scenarios :
 ### Requirements
 
 * Docker (Installation [here](https://docs.docker.com/engine/installation/))
+* For preparing, a local installation of wget (for macOS)
 * For local testing, make sure you can run the [docker-compose command](https://docs.docker.com/compose/install/)
 
 ## Usage
@@ -68,7 +70,7 @@ docker run -it \
 
 ## Features
 
-This project uses the same base technology than Mendix uses to run application in Cloud Foundry (the [mendix cloudfoundry buildpack](https://github.com/mendix/cf-mendix-buildpack)).
+This project uses the same base technology that Mendix uses to run application in Cloud Foundry (the [mendix cloudfoundry buildpack](https://github.com/mendix/cf-mendix-buildpack)).
 
 * Compilation of a Mendix application from project sources
 * Automatic generation of the configuration (_m2ee.yaml_)
@@ -83,10 +85,12 @@ This project uses the same base technology than Mendix uses to run application i
 ### Enabling licensed
 
 If you wish to start your application with a non-trial license, please provide the additional environment variables
+
 * LICENSE_ID
 * LICENSE_KEY
 
 example:
+
 ```
 docker run -it \
   -p 8080:80 \
@@ -102,6 +106,7 @@ docker run -it \
 The default values for constants will be used as defined in your project. However, you can override them with environment variables. You need to replace the dot with an underscore and prefix it with MX_. So a constant like Module.Constant with value ABC123 could be set like this:
 
 example:
+
 ```
 docker run -it \
   -p 8080:80 \
@@ -120,6 +125,7 @@ To configure any of the advanced Custom Runtime Settings you can use setting nam
 For example, to configure the ConnectionPoolingMinIdle setting to value 10, you can set the following environment variable:
 
 example:
+
 ```
 docker run -it \
   -p 8080:80 \
@@ -161,6 +167,7 @@ Configuring log levels happens by adding one or more environment variables start
     }
 
 You can see the available Log Nodes in your application in the Mendix Modeler. The level should be one of:
+
  * `CRITICAL`
  * `ERROR`
  * `WARNING`

--- a/tests/docker-compose-azuresql.yml
+++ b/tests/docker-compose-azuresql.yml
@@ -1,18 +1,13 @@
-version: '2.1'
+mendixapp:
+    image: mendix/mendix-buildpack:v1.2
+    environment:
+        - ADMIN_PASSWORD=Password1!
+        - DATABASE_ENDPOINT=jdbc:sqlserver://db:1433;database=mendix;user=sa;password=Password1!
+    ports:
+        - 8080:80
+        - 8090:81
+    links:
+        - db
 
-services:
-    mendixapp:
-        image: mendix/mendix-buildpack:v1
-        depends_on:
-          - db
-        environment:
-            - ADMIN_PASSWORD=Password1!
-            - DATABASE_ENDPOINT=jdbc:sqlserver://db:1433;database=mendix;user=sa;password=Password1!
-        ports:
-            - 8080:80
-            - 8090:81
-        links:
-            - db
-
-    db:
-        image: mendix/mendix_test_sqlserver:v1
+db:
+    image: mendix/mendix_test_sqlserver:v1

--- a/tests/docker-compose-postgres.yml
+++ b/tests/docker-compose-postgres.yml
@@ -1,5 +1,5 @@
 mendixapp:
-    image: mendix/mendix-buildpack:v1
+    image: mendix/mendix-buildpack:v1.2
     environment:
         - ADMIN_PASSWORD=Password1!
         - DATABASE_ENDPOINT=postgres://mendix:mendix@db:5432/mendix

--- a/tests/docker-compose-sqlserver.yml
+++ b/tests/docker-compose-sqlserver.yml
@@ -1,18 +1,13 @@
-version: '2.1'
+mendixapp:
+    image: mendix/mendix-buildpack:v1.2
+    environment:
+        - ADMIN_PASSWORD=Password1!
+        - DATABASE_ENDPOINT=sqlserver://sa:Password1!@db:1433/mendix
+    ports:
+        - 8080:80
+        - 8090:81
+    links:
+        - db
 
-services:
-    mendixapp:
-        image: mendix/mendix-buildpack:v1
-        depends_on:
-          - db
-        environment:
-            - ADMIN_PASSWORD=Password1!
-            - DATABASE_ENDPOINT=sqlserver://sa:Password1!@db:1433/mendix
-        ports:
-            - 8080:80
-            - 8090:81
-        links:
-            - db
-
-    db:
-        image: mendix/mendix_test_sqlserver:v1
+db:
+    image: mendix/mendix_test_sqlserver:v1

--- a/tests/test-generic.sh
+++ b/tests/test-generic.sh
@@ -11,9 +11,9 @@ curl http://localhost:8080 | grep "<title>Mendix</title>"
 RETURN_CODE=$?
 if [ $RETURN_CODE -eq "0" ]; then
   echo "test.sh [TEST SUCCESS] App is reachable for $COMPOSEFILE"
-  docker-compose -f $COMPOSEFILE down
+  docker-compose -f $COMPOSEFILE kill
 else
   echo "test.sh [TEST FAILED] App is not reachable in timeout delay $TIMEOUT for $COMPOSEFILE"
-  docker-compose -f $COMPOSEFILE down
+  docker-compose -f $COMPOSEFILE kill
 fi
 exit $RETURN_CODE


### PR DESCRIPTION
Shrink the docker image by cleaning cache and temporary files.
Fixed an issue with the Makefile.
Minor updates for the README.md (and making is correctly parsed in MacDown).