### PR TITLE
Added default build_path value

### DIFF
--- a/.travistest.sh
+++ b/.travistest.sh
@@ -5,3 +5,7 @@ make build-image
 tests/test-generic.sh tests/docker-compose-postgres.yml
 tests/test-generic.sh tests/docker-compose-sqlserver.yml
 tests/test-generic.sh tests/docker-compose-azuresql.yml
+#build alternative build directory only for PostgreSQL
+make get-sample-alt
+make build-image-alt
+tests/test-generic.sh tests/docker-compose-postgres-alt.yml

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN apt-get -q -y update && \
   DEBIAN_FRONTEND=noninteractive apt-get install -q -y python wget libgdiplus libpq5
 
 # Build-time variables
-ARG BUILD_PATH
+ARG BUILD_PATH=build
 
 # Checkout CF Build-pack here
 RUN mkdir -p buildpack/.local && \

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,8 @@ run-test-container:
 	docker-compose -f tests/docker-compose-postgres.yml
 # Build from alternative location
 get-sample-alt:
+	# Also remove normal build directory
+	if [ -d build ]; then rm -rf build; fi
 	if [ -d buildalt ]; then rm -rf buildalt; fi
 	if [ -d downloads ]; then rm -rf downloads; fi
 	mkdir -p downloads buildalt

--- a/Makefile
+++ b/Makefile
@@ -23,4 +23,4 @@ get-sample-alt:
 build-image-alt:
 	docker build \
 	--build-arg BUILD_PATH=buildalt \
-	-t mendix/mendix-buildpack:v1 .
+	-t mendix/mendix-buildpack:v1-alt .

--- a/Makefile
+++ b/Makefile
@@ -6,7 +6,6 @@ get-sample:
 	unzip downloads/application.mpk -d build/
 build-image:
 	docker build \
-	--build-arg BUILD_PATH=build \
 	-t mendix/mendix-buildpack:v1 .
 test-container:
 	tests/test-generic.sh tests/docker-compose-postgres.yml
@@ -14,3 +13,14 @@ test-container:
 	tests/test-generic.sh tests/docker-compose-azuresql.yml
 run-test-container:
 	docker-compose -f tests/docker-compose-postgres.yml
+# Build in alternative location
+get-sample-alt:
+	if [ -d buildalt ]; then rm -rf buildalt; fi
+	if [ -d downloads ]; then rm -rf downloads; fi
+	mkdir -p downloads buildalt
+	wget https://cdn.mendix.com/sample/SampleAppA.mpk -O downloads/application.mpk
+	unzip downloads/application.mpk -d buildalt/
+build-image-alt:
+	docker build \
+	--build-arg BUILD_PATH=buildalt \
+	-t mendix/mendix-buildpack:v1 .

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ test-container:
 	tests/test-generic.sh tests/docker-compose-azuresql.yml
 run-test-container:
 	docker-compose -f tests/docker-compose-postgres.yml
-# Build in alternative location
+# Build from alternative location
 get-sample-alt:
 	if [ -d buildalt ]; then rm -rf buildalt; fi
 	if [ -d downloads ]; then rm -rf downloads; fi

--- a/tests/docker-compose-postgres-alt.yml
+++ b/tests/docker-compose-postgres-alt.yml
@@ -1,0 +1,16 @@
+mendixapp:
+    image: mendix/mendix-buildpack:v1-alt
+    environment:
+        - ADMIN_PASSWORD=Password1!
+        - DATABASE_ENDPOINT=postgres://mendix:mendix@db:5432/mendix
+    ports:
+        - 8080:80
+        - 8090:81
+    links:
+        - db
+
+db:
+    image: postgres
+    environment:
+        - POSTGRES_USER=mendix
+        - POSTGRES_PASSWORD=mendix


### PR DESCRIPTION
Added default build_path value (=build) when not passed from as build argument to Docker. This allows for easier usage of the build pack in CI/CD environment. For example when used in conjunction with Docker plugins for Jenkins which do not seem to allow passing of environment variables to build slaves.