### PR TITLE
Add hostname instance count evaluation when deploying on Kubernetes

### DIFF
--- a/scripts/startup
+++ b/scripts/startup
@@ -2,6 +2,7 @@
 import json
 import logging
 import os
+import re
 import subprocess
 import sys
 
@@ -65,6 +66,17 @@ def create_vcap_application():
     vcap_application_data = open("vcap_application.json").read()
     return vcap_application_data
 
+def export_k8s_instance():
+    logging.debug("Checking Kubernetes environment...")
+    kubernetes_host = os.environ['KUBERNETES_SERVICE_HOST']
+    if kubernetes_host is not None:
+        hostname = os.environ['HOSTNAME']
+        instance_match = re.search('(?<=-)[0-9]+$', hostname)
+        if instance_match is not None:
+            instance_number = instance_match.group(0)
+            logging.info("Setting CF_INSTANCE_INDEX to {0} based on hostname {1}"
+                .format(instance_number, hostname))
+            os.environ['CF_INSTANCE_INDEX'] = instance_number 
 
 def call_builpack_startup():
     logging.debug("Executing call_builpack_startup...")
@@ -98,5 +110,6 @@ def get_welcome_header():
 if __name__ == '__main__':
     logging.info(get_welcome_header())
     export_vcap_variables()
+    export_k8s_instance()
     call_builpack_startup()
     sys.exit(0)


### PR DESCRIPTION
For Kubernetes try to determine the instance index based on the hostname which is set to a numeric suffix when using a StatefulSet. 
