### PR TITLE
Remove JDK, Docs & Mono after compilation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ COPY $BUILD_PATH build
 # Compile the application source code and remove temp files
 WORKDIR /buildpack
 RUN "/buildpack/compilation" /build /cache && \
+  rm -fr /cache /tmp/javasdk /tmp/opt
 
 # Expose nginx port
 ENV PORT 80

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,6 @@ COPY $BUILD_PATH build
 # Compile the application source code and remove temp files
 WORKDIR /buildpack
 RUN "/buildpack/compilation" /build /cache && \
-  rm -fr /cache /tmp/javasdk /tmp/opt /build/.local/usr/lib/jvm/jre-*
 
 # Expose nginx port
 ENV PORT 80

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ COPY $BUILD_PATH build
 # Compile the application source code and remove temp files
 WORKDIR /buildpack
 RUN "/buildpack/compilation" /build /cache && \
-  rm -fr /cache /tmp/javasdk /build/.local/usr/lib/jvm/jdk-* /usr/share/doc/*
+  rm -fr /cache /tmp/javasdk /build/.local/usr/lib/jvm/jdk-* /usr/share/doc/* /tmp/opt/mono-*
 
 # Expose nginx port
 ENV PORT 80

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ COPY $BUILD_PATH build
 # Compile the application source code and remove temp files
 WORKDIR /buildpack
 RUN "/buildpack/compilation" /build /cache && \
-  rm -fr /cache /tmp/javasdk /build/.local/usr/lib/jvm/jdk-* /usr/share/doc/* /tmp/opt/mono-*
+  rm -fr /cache /tmp/javasdk /tmp/opt /build/.local/usr/lib/jvm/jdk-* /usr/share/doc/*
 
 # Expose nginx port
 ENV PORT 80

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ COPY $BUILD_PATH build
 # Compile the application source code and remove temp files
 WORKDIR /buildpack
 RUN "/buildpack/compilation" /build /cache && \
-  rm -fr /cache /tmp/javasdk /tmp/opt
+  rm -fr /cache /tmp/javasdk /build/.local/usr/lib/jvm/jdk-* /usr/share/doc/*
 
 # Expose nginx port
 ENV PORT 80

--- a/Dockerfile.full
+++ b/Dockerfile.full
@@ -35,7 +35,7 @@ COPY $BUILD_PATH build
 # Compile the application source code and remove temp files
 WORKDIR /buildpack
 RUN "/buildpack/compilation" /build /cache && \
-  rm -fr /cache /tmp/javasdk /tmp/opt
+  rm -fr /cache /tmp/javasdk /build/.local/usr/lib/jvm/jdk-* /usr/share/doc/* /tmp/opt/mono-*
 
 # Expose nginx port
 ENV PORT 80

--- a/Dockerfile.full
+++ b/Dockerfile.full
@@ -35,7 +35,7 @@ COPY $BUILD_PATH build
 # Compile the application source code and remove temp files
 WORKDIR /buildpack
 RUN "/buildpack/compilation" /build /cache && \
-  rm -fr /cache /tmp/javasdk /build/.local/usr/lib/jvm/jdk-* /usr/share/doc/* /tmp/opt/mono-*
+  rm -fr /cache /tmp/javasdk /tmp/opt /build/.local/usr/lib/jvm/jdk-* /usr/share/doc/*
 
 # Expose nginx port
 ENV PORT 80


### PR DESCRIPTION
Changes to Dockerfile to remove JDK, Docs & Mono post-compilation, saving 378 MB of image size.