### PR TITLE
CERTIFICATE_AUTHORITIES_BASE64 encoding errors after upgrade to Python3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,6 @@ LABEL maintainer="digitalecosystems@mendix.com"
 
 # Build-time variables
 ARG BUILD_PATH=project
-ARG BLOBSTORE
 
 # Checkout CF Build-pack here
 RUN mkdir -p buildpack/.local && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,6 +28,7 @@ COPY $BUILD_PATH build
 # Compile the application source code and remove temp files
 WORKDIR /buildpack
 RUN "/buildpack/compilation" /build /cache && \
+  rm -fr /cache /tmp/javasdk /tmp/opt
 
 # Expose nginx port
 ENV PORT 80

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,6 @@ COPY $BUILD_PATH build
 # Compile the application source code and remove temp files
 WORKDIR /buildpack
 RUN "/buildpack/compilation" /build /cache && \
-  rm -fr /cache /tmp/javasdk /tmp/opt /build/.local/usr/lib/jvm/jre-*
 
 # Expose nginx port
 ENV PORT 80

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ LABEL maintainer="digitalecosystems@mendix.com"
 
 # Build-time variables
 ARG BUILD_PATH=project
+ARG BLOBSTORE
 
 # Checkout CF Build-pack here
 RUN mkdir -p buildpack/.local && \

--- a/scripts/startup
+++ b/scripts/startup
@@ -86,7 +86,7 @@ def export_encoded_cacertificates():
     certificate_authorities_base64 = os.environ.get('CERTIFICATE_AUTHORITIES_BASE64')
     if certificate_authorities_base64 is not None:
         logging.info("Decoding encoded CA certificates into CERTIFICATE_AUTHORITIES environment variable")
-        os.environ['CERTIFICATE_AUTHORITIES'] = base64.b64decode(certificate_authorities_base64)
+        os.environ['CERTIFICATE_AUTHORITIES'] = str(base64.b64decode(certificate_authorities_base64))
             
 def call_builpack_startup():
     logging.debug("Executing call_builpack_startup...")


### PR DESCRIPTION
Last pull request upgraded the build pack to Python3 (DEP-336). This introduced an encoding error (see https://github.com/unbit/uwsgi/issues/1432) when using CERTIFICATE_AUTHORITIES_BASE64: 

> INFO: 
>                               ##        .
>                          ## ## ##       ==
>                        ## ## ## ##      ===
>                    /""""""""""""""""\___/ ===
>               ~~~ {~~ ~~~~ ~~~ ~~~~ ~~ ~ /  ===- ~~~
>                    \______ o          __/
>                      \    \        __/
>                       \____\______/
> 
>      __  __        _  _     _____             _
>     |  \/  |      | || |   |  __ \           | |
>     | \  / |_  __ | || |_  | |  | | ___   ___| | _____ _ __
>     | |\/| \ \/ / |__   _| | |  | |/ _ \ / __| |/ / _ \ '__|
>     | |  | |>  <     | |   | |__| | (_) | (__|   <  __/ |
>     |_|  |_/_/\_\    |_|   |_____/ \___/ \___|_|\_\___|_|
> 
>                                 digitalecosystems@mendix.com
> 
> 
>     
> INFO: Decoding encoded CA certificates into CERTIFICATE_AUTHORITIES environment variable
> Traceback (most recent call last):
>   File "/build/startup", line 124, in <module>
>     export_encoded_cacertificates()
>   File "/build/startup", line 89, in export_encoded_cacertificates
>     os.environ['CERTIFICATE_AUTHORITIES'] = base64.b64decode(certificate_authorities_base64)
>   File "/usr/lib/python3.4/os.py", line 638, in __setitem__
>     value = self.encodevalue(value)
>   File "/usr/lib/python3.4/os.py", line 706, in encode
>     raise TypeError("str expected, not %s" % type(value).__name__)
> TypeError: str expected, not bytes

This can be fixed by explicitly casting the decoded certificate to a string when setting it as an environment variable.