### PR TITLE
Enable Datadog integration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ LABEL maintainer="digitalecosystems@mendix.com"
 
 # Build-time variables
 ARG BUILD_PATH=project
+ARG DD_API_KEY
 
 # Checkout CF Build-pack here
 RUN mkdir -p buildpack/.local && \

--- a/Dockerfile.full
+++ b/Dockerfile.full
@@ -21,6 +21,7 @@ RUN apt-get -q -y update && \
 
 # Build-time variables
 ARG BUILD_PATH=project
+ARG DD_API_KEY
 
 # Checkout CF Build-pack here
 RUN mkdir -p buildpack/.local && \


### PR DESCRIPTION
Added DD_API_KEY to Dockerfile to allow enablement of Docker integration.