### PR TITLE
Clarified admin port settings in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,10 @@ docker run -it \
 
 The admin interface can be used to measure the health of the Runtime as per [documentation](https://docs.mendix.com/refguide/monitoring-mendix-runtime). The password of the admin port can be set using the environment variable M2EE_PASSWORD. The standard username is MxAdmin. The interface is exposed to the outside world on the url /_mxadmin/ and can be accessed by using basic HTTP authentication. Refer to the [documentation](https://docs.mendix.com/refguide/monitoring-mendix-runtime) to learn how to use this interface.
 
+To clarify: 
+- the HTTP basic authentication credentials are: MxAdmin / [M2EE_PASSWORD] .
+- the X-M2EE-Authentication header contains a base64-encoded version of [M2EE_PASSWORD] .
+
 ### Health check
 
 The docker compose files, in the ```/test``` folder, contain an example how to perform a healtcheck on a Mendix app:


### PR DESCRIPTION
Had a customer running into issues, finding it not really clear what should be encoded and what not