### PR TITLE
WIP: Run container as non-root

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,9 @@ FROM mendix/rootfs
 LABEL Author="Mendix Digital Ecosystems"
 LABEL maintainer="digitalecosystems@mendix.com"
 
+# Run as nobody
+USER nobody
+
 # Build-time variables
 ARG BUILD_PATH=project
 ARG DD_API_KEY

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,6 @@ COPY scripts/ /build
 WORKDIR /build
 RUN chmod u+x startup
 # Prepare to run as mendix
-RUN chown -R mendix.mendix /buildpack /build /.java /root /root/.m2ee
+RUN chown -R mendix.mendix /buildpack /build /.java /root
 USER mendix
 ENTRYPOINT ["/build/startup","/buildpack/start.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,8 +7,9 @@ FROM mendix/rootfs
 LABEL Author="Mendix Digital Ecosystems"
 LABEL maintainer="digitalecosystems@mendix.com"
 
-# Run as nobody
-USER nobody
+# Create mendix user
+RUN groupadd -g 999 mendix && \
+    useradd -r -d /root -u 999 -g mendix mendix
 
 # Build-time variables
 ARG BUILD_PATH=project
@@ -35,7 +36,7 @@ RUN "/buildpack/compilation" /build /cache && \
   rm -fr /cache /tmp/javasdk /tmp/opt
 
 # Expose nginx port
-ENV PORT 80
+ENV PORT 8080
 EXPOSE $PORT
 
 RUN mkdir -p "/.java/.userPrefs/com/mendix/core"
@@ -46,4 +47,7 @@ RUN ln -s "/.java/.userPrefs/com/mendix/core/prefs.xml" "/root/.java/.userPrefs/
 COPY scripts/ /build
 WORKDIR /build
 RUN chmod u+x startup
+# Prepare to run as mendix
+RUN chown -R mendix.mendix /buildpack /build /.java /root
+USER mendix
 ENTRYPOINT ["/build/startup","/buildpack/start.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,6 @@ COPY scripts/ /build
 WORKDIR /build
 RUN chmod u+x startup
 # Prepare to run as mendix
-RUN chown -R mendix.mendix /buildpack /build /.java /root && ls -la /root
+RUN chown -R mendix.mendix /buildpack /build /.java /root /root/.m2ee
 USER mendix
 ENTRYPOINT ["/build/startup","/buildpack/start.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,6 @@ COPY scripts/ /build
 WORKDIR /build
 RUN chmod u+x startup
 # Prepare to run as mendix
-RUN chown -R mendix.mendix /buildpack /build /.java /root
-USER mendix
+RUN chown -R 999:999 /buildpack /build /.java /root
+USER 999
 ENTRYPOINT ["/build/startup","/buildpack/start.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -48,6 +48,6 @@ COPY scripts/ /build
 WORKDIR /build
 RUN chmod u+x startup
 # Prepare to run as mendix
-RUN chown -R mendix.mendix /buildpack /build /.java /root
+RUN chown -R mendix.mendix /buildpack /build /.java /root && ls -la /root
 USER mendix
 ENTRYPOINT ["/build/startup","/buildpack/start.py"]

--- a/tests/docker-compose-postgres.yml
+++ b/tests/docker-compose-postgres.yml
@@ -79,8 +79,8 @@ services:
                 yW7wMeYCUfgTNWaSaJd6uYUjj+IP/9+YOkp5pLW5eEAq6YscYA==
                 -----END CERTIFICATE-----
         ports:
-            - 8080:80
-            - 8090:81
+            - 8080:8080
+            - 8090:8081
         links:
             - db
         # restart: always


### PR DESCRIPTION
**DO NOT MERGE YET**

This is a working, but dirty implementation that allows the Docker container to run as non-root
It needs further work because:

- It has not been extensively tested. It works on-premise Kubernetes, but not on Google Kubernetes Engine, for example (permission problems).
- Increases build time considerably because it changes file ownership recursively for the whole image in a non-optimized way (chown -R at the end of the Dockerfile). This can be done in a better way
- It changes the port nginx listens to from 80 to 8080 and thus is breaking for existing customer implementations.