### PR TITLE
Add APPMETRICS_TARGET build arg

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,7 @@ LABEL maintainer="digitalecosystems@mendix.com"
 # Build-time variables
 ARG BUILD_PATH=project
 ARG DD_API_KEY
+ARG APPMETRICS_TARGET
 
 # Checkout CF Build-pack here
 RUN mkdir -p buildpack/.local && \


### PR DESCRIPTION
The APPMETRICS_TARGET variable needs to be non-empty on build time for the telegraf agent to be included in the container.