### PR TITLE
Updated git clone for Windows

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Open a terminal and run the following code:
 > Important note: always provide `<TAG>` value to guarantee consistent builds. List of tags is available [here](https://github.com/mendix/docker-mendix-buildpack/tags).
 
 ```
-git clone --branch <TAG> https://github.com/mendix/docker-mendix-buildpack
+git clone --branch <TAG> --config core.autocrlf=false https://github.com/mendix/docker-mendix-buildpack
 cd docker-mendix-buildpack
 make get-sample
 make build-image


### PR DESCRIPTION
Updated the git clone command for Windows:
Conversion of line ending should be disabled.