### PR TITLE
Makefile compatible for WINDOWS and LINUX OS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,18 @@
 get-sample:
+ifeq ($(OS),Windows_NT)
+	if exist "build" rmdir /Q /S build
+	if exist "downloads" rmdir /Q /S downloads
+	mkdir downloads build
+	wget http://cdn.mendix.com/sample/SampleAppA.mpk -O downloads/application.mpk
+	unzip downloads/application.mpk -d build/
+else
 	if [ -d build ]; then rm -rf build; fi
 	if [ -d downloads ]; then rm -rf downloads; fi
 	mkdir -p downloads build
 	wget https://cdn.mendix.com/sample/SampleAppA.mpk -O downloads/application.mpk
-	unzip downloads/application.mpk -d build/
-
+	unzip downloads/application.mpk -d build/	
+endif
+	
 build-image:
 	docker build \
 	--build-arg BUILD_PATH=build \


### PR DESCRIPTION
Issue: Makefile was not compatible with WINDOWS Operating System.
Solution:
I have made changes to the Makefile to detect the Operating System and execute the command accordingly.

Pre-requisites for Makefile:
1. Install Make from GnuWin32
2. Set the bin folder path of GnuWin32 in the Environment Variables.
3. Install wget