### PR TITLE
DES-1550 Shrink the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,10 @@
 #
 # Author: Mendix Digital Ecosystems, digitalecosystems@mendix.com
 # Version: 2.0.0
-ARG ROOTFS_IMAGE=mendix/rootfs:trusty
+ARG ROOTFS_IMAGE=mendix/rootfs:bionic
 
-FROM ${ROOTFS_IMAGE}
-LABEL Author="Mendix Digital Ecosystems"
-LABEL maintainer="digitalecosystems@mendix.com"
+# Build stage
+FROM ${ROOTFS_IMAGE} AS builder
 
 # Build-time variables
 ARG BUILD_PATH=project
@@ -17,50 +16,74 @@ ARG CF_BUILDPACK=master
 
 # Each comment corresponds to the script line:
 # 1. Create all directories needed by scripts
-# 2. Create mendix user with home directory at /opt/mendix/build
-# 4. Download CF buildpack
-# 5. Update the owner and group for /opt/mendix so that the app can run as a non-root user
-# 6. Update permissions for /opt/mendix so that the app can run as a non-root user
-# 7. Allow the root group to modify /etc/passwd so that the startup script can update the non-root uid
+# 2. Download CF buildpack
+# 4. Update ownership of /opt/mendix so that the app can run as a non-root user
+# 5. Update permissions of /opt/mendix so that the app can run as a non-root user
 RUN mkdir -p /opt/mendix/buildpack /opt/mendix/build &&\
-   useradd -r -g root -d /opt/mendix/build mendix &&\
    echo "CF Buildpack version ${CF_BUILDPACK}" &&\
-   wget -qO- https://github.com/mendix/cf-mendix-buildpack/archive/${CF_BUILDPACK}.tar.gz | tar xvz -C /opt/mendix/buildpack --strip-components 1 &&\
-   chown -R mendix:root /opt/mendix &&\
-   chmod -R g+rwX /opt/mendix &&\
-   chmod g+w /etc/passwd
+   curl -fsSL https://github.com/mendix/cf-mendix-buildpack/archive/${CF_BUILDPACK}.tar.gz | tar xvz -C /opt/mendix/buildpack --strip-components 1 &&\
+   chgrp -R 0 /opt/mendix &&\
+   chmod -R g=u  /opt/mendix
 
 # Copy python scripts which execute the buildpack (exporting the VCAP variables)
-COPY --chown=mendix:root scripts/compilation scripts/git /opt/mendix/buildpack/
+COPY scripts/compilation scripts/git /opt/mendix/buildpack/
+
+# Copy cleanupjdk script which will delete the JDK after a successful build
+COPY scripts/cleanupjdk /opt/mendix/buildpack/bin
+
 # Copy project model/sources
-COPY --chown=mendix:root $BUILD_PATH /opt/mendix/build
+COPY $BUILD_PATH /opt/mendix/build
 
 # Add the buildpack modules
 ENV PYTHONPATH "/opt/mendix/buildpack/lib/"
 
 # Each comment corresponds to the script line:
 # 1. Create cache directory
-# 2. Set permissions for compilation script
-# 3. Call compilation script
-# 4. Remove temporary folders
-# 5. Create symlink for java prefs used by CF buildpack
-# 6. Update ownership of /opt/mendix so that the app can run as a non-root user
-# 7. Update permissions for /opt/mendix/build so that the app can run as a non-root user
-WORKDIR /opt/mendix/buildpack
+# 2. Set permissions for compilation scripts
+# 3. Navigate to buildpack directory
+# 4. Call compilation script
+# 5. Remove the JDK which is not needed after the build completes
+# 6. Remove temporary files
+# 7. Create symlink for java prefs used by CF buildpack
+# 8. Update ownership of /opt/mendix so that the app can run as a non-root user
+# 9. Update permissions of /opt/mendix so that the app can run as a non-root user
 RUN mkdir -p /tmp/buildcache &&\
-    chmod +rx /opt/mendix/buildpack/compilation /opt/mendix/buildpack/git &&\
-    "/opt/mendix/buildpack/compilation" /opt/mendix/build /tmp/buildcache &&\
-    rm -fr /tmp/buildcache /tmp/javasdk /tmp/opt &&\
+    chmod +rx /opt/mendix/buildpack/compilation /opt/mendix/buildpack/git /opt/mendix/buildpack/bin/cleanupjdk &&\
+    cd /opt/mendix/buildpack &&\
+    ./compilation /opt/mendix/build /tmp/buildcache &&\
+    bin/cleanupjdk /opt/mendix/build /tmp/buildcache &&\
+    rm -fr /tmp/buildcache /tmp/javasdk /tmp/opt bin/cleanupjdk compilation &&\
     ln -s /opt/mendix/.java /opt/mendix/build &&\
-    chown -R mendix:root /opt/mendix &&\
-    chmod -R g+rwX /opt/mendix
+    chgrp -R 0 /opt/mendix &&\
+    chmod -R g=u /opt/mendix
+
+FROM ${ROOTFS_IMAGE}
+LABEL Author="Mendix Digital Ecosystems"
+LABEL maintainer="digitalecosystems@mendix.com"
+
+# Allow the root group to modify /etc/passwd so that the startup script can update the non-root uid
+RUN chmod g=u /etc/passwd
+
+# Add the buildpack modules
+ENV PYTHONPATH "/opt/mendix/buildpack/lib/"
 
 # Copy start scripts
-COPY --chown=mendix:root scripts/startup /opt/mendix/build
-COPY --chown=mendix:root scripts/vcap_application.json /opt/mendix/build
+COPY scripts/startup scripts/vcap_application.json /opt/mendix/build/
+
+# Each comment corresponds to the script line:
+# 1. Make the startup script executable
+# 2. Update ownership of /opt/mendix so that the app can run as a non-root user
+# 3. Update permissions of /opt/mendix so that the app can run as a non-root user
+RUN chmod +rx /opt/mendix/build/startup &&\
+    chgrp -R 0 /opt/mendix &&\
+    chmod -R g=u /opt/mendix
+
+# Copy build artifacts from build container
+COPY --from=builder /opt/mendix /opt/mendix
+
 WORKDIR /opt/mendix/build
 
-USER mendix
+USER 1001
 
 ENV HOME "/opt/mendix/build"
 

--- a/scripts/cleanupjdk
+++ b/scripts/cleanupjdk
@@ -1,0 +1,14 @@
+#!/usr/bin/env python3
+import shutil
+import logging
+import os
+import sys
+import buildpackutil
+from compile import get_runtime_version, DOT_LOCAL_LOCATION
+
+if __name__ == '__main__':
+    logging.info("Deleting JDK...")
+    get_runtime_version()
+    jdk = buildpackutil._determine_jdk(get_runtime_version(), 'jdk')
+    jdk_path = os.path.join(DOT_LOCAL_LOCATION, buildpackutil._compose_jvm_target_dir(jdk))
+    shutil.rmtree(jdk_path, ignore_errors=False)

--- a/scripts/compilation
+++ b/scripts/compilation
@@ -4,6 +4,10 @@ import logging
 import os
 import subprocess
 import sys
+import shutil
+
+import buildpackutil
+from bin.compile import get_runtime_version, DOT_LOCAL_LOCATION
 
 BUILD_PATH = sys.argv[1]
 CACHE_PATH = sys.argv[2]
@@ -32,9 +36,33 @@ def call_buildpack_compilation():
     logging.debug("Executing call_buildpack_compilation...")
     return subprocess.call(["/opt/mendix/buildpack/bin/compile", BUILD_PATH, CACHE_PATH])
 
+def remove_jdk():
+    logging.info("Removing JDK...")
+    get_runtime_version()
+    jdk = buildpackutil._determine_jdk(get_runtime_version(), 'jdk')
+    jdk_path = os.path.join(DOT_LOCAL_LOCATION, buildpackutil._compose_jvm_target_dir(jdk))
+    if os.path.exists(jdk_path):
+        shutil.rmtree(jdk_path, ignore_errors=False)
+
+def make_dependencies_reusable():
+    logging.info("Making dependencies reusable...")
+    shutil.move("/opt/mendix/build/runtimes", "/var/mendix/build/")
+    shutil.move("/opt/mendix/build/.local/usr", "/var/mendix/build/.local/")
+    # separate cacerts from reusable jre components
+    jre = buildpackutil._determine_jdk(get_runtime_version(), 'jre')
+    jvm_location_reusable = os.path.join("/var/mendix/build/.local/", buildpackutil._compose_jvm_target_dir(jre))
+    jvm_location_customized = os.path.join(DOT_LOCAL_LOCATION, buildpackutil._compose_jvm_target_dir(jre))
+    cacerts_file_source = os.path.join(jvm_location_reusable, "lib", "security", "cacerts")
+    cacerts_file_target = os.path.join(jvm_location_customized, "lib", "security", "cacerts")
+    buildpackutil.mkdir_p(os.path.dirname(cacerts_file_target))
+    os.rename(cacerts_file_source, cacerts_file_target)
+
 if __name__ == '__main__':
     logging.info("Mendix project compilation phase...")
 
     export_vcap_services()
     exit_code = call_buildpack_compilation()
-    sys.exit(exit_code)
+    if exit_code != 0:
+        sys.exit(exit_code)
+    remove_jdk()
+    make_dependencies_reusable()

--- a/scripts/startup
+++ b/scripts/startup
@@ -83,14 +83,9 @@ def call_buildpack_startup():
     proc.wait()
 
 def add_uid():
-    try:
-        pwd.getpwuid(os.getuid())
-    except KeyError:
-        logging.info("Adding uid to /etc/passwd")
-        with open('/etc/passwd', 'r' ) as f:
-            passwd = f.read()
-        passwd = re.sub('^(mendix:x):(\d+:\d+):(.*)$', '\\1:{uid}:{gid}:\\3'.format(uid=os.getuid(), gid=os.getgid()), passwd, flags = re.M)
-        open('/etc/passwd','w').writelines(passwd)
+    logging.info("Adding uid to /etc/passwd")
+    with open('/etc/passwd','a') as passwd_file:
+        passwd_file.write('mendix:x:{uid}:0:mendix user:/opt/mendix/build:/sbin/nologin\n'.format(uid=os.getuid()))
 
 def get_welcome_header():
     welcome_ascii_header = '''


### PR DESCRIPTION
- Use a multistage build to discard dependencies and artifacts needed only during build time
- Delete the JDK in case after the project has been built
- Rearrange dependencies in build container and load them as separate layers into the app container:
    - This makes it possible to use the Docker build cache and reuse the JRE and MxRuntime between apps
    - This approach works only if images are built on the same Docker daemon, without cleaning up the cache