### PR TITLE
Use subprocess.check_call(...) because if the child process fails, it breaks docker build

### DIFF
--- a/scripts/compilation
+++ b/scripts/compilation
@@ -34,7 +34,7 @@ def export_vcap_services():
 
 def call_buildpack_compilation():
     logging.debug("Executing call_buildpack_compilation...")
-    return subprocess.call(["/opt/mendix/buildpack/buildpack/compile.py", BUILD_PATH, CACHE_PATH])
+    return subprocess.check_call(["/opt/mendix/buildpack/buildpack/compile.py", BUILD_PATH, CACHE_PATH])
     # return subprocess.call(["/opt/mendix/buildpack/bin/compile", BUILD_PATH, CACHE_PATH])
 
 def remove_jdk():


### PR DESCRIPTION
If the docker build process continues despite a build error, the resulting docker image is broken.

When used in a pipeline, it's not obvious the problem is due to a model compilation error (often).
