### PR TITLE
Start testing before the "startup timeout" ends

### DIFF
--- a/tests/test-generic.sh
+++ b/tests/test-generic.sh
@@ -3,21 +3,22 @@ set -u
 
 BASEDIR=$(dirname "$0")
 COMPOSEFILE=$1
+TIMEOUT=180s
 
 export BUILDPACK_VERSION="${BUILDPACK_VERSION:-$(cat $BASEDIR/../docker-buildpack.version)}"
 
 echo "Testing buildpack version ${BUILDPACK_VERSION}"
 echo "test.sh [TEST STARTED] starting docker-compose $COMPOSEFILE"
 docker-compose -f $COMPOSEFILE up &
-TIMEOUT=180
-sleep $TIMEOUT
+
+timeout $TIMEOUT bash -c 'until curl http://localhost:8080 | grep "<title>Mendix</title>"; do sleep 5; done'
+
 curl http://localhost:8080 | grep "<title>Mendix</title>"
 RETURN_CODE=$?
 if [ $RETURN_CODE -eq "0" ]; then
   echo "test.sh [TEST SUCCESS] App is reachable for $COMPOSEFILE"
-  docker-compose -f $COMPOSEFILE kill
 else
   echo "test.sh [TEST FAILED] App is not reachable in timeout delay $TIMEOUT for $COMPOSEFILE"
-  docker-compose -f $COMPOSEFILE kill
 fi
+docker-compose -f $COMPOSEFILE kill
 exit $RETURN_CODE


### PR DESCRIPTION
Instead of unconditionally waiting for 180 seconds, test if the app is up and running in a loop.

If the app container starts up immediately, this reduce the test time by 3 minutes (or even more if additional tests are run).