### PR TITLE
DES-2719 Vulnerability workarounds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,9 @@ FROM ${ROOTFS_IMAGE} AS builder
 ARG BUILD_PATH=project
 ARG DD_API_KEY
 # CF buildpack version
-ARG CF_BUILDPACK=v4.13.4
+ARG CF_BUILDPACK=v4.13.6
+# Exclude the logfilter binary by default
+ARG EXCLUDE_LOGFILTER=true
 
 # Each comment corresponds to the script line:
 # 1. Create all directories needed by scripts

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,8 +65,17 @@ FROM ${ROOTFS_IMAGE}
 LABEL Author="Mendix Digital Ecosystems"
 LABEL maintainer="digitalecosystems@mendix.com"
 
+# Uninstall build-time dependencies to remove potentially vulnerable libraries
+ARG UNINSTALL_BUILD_DEPENDENCIES=true
+
 # Allow the root group to modify /etc/passwd so that the startup script can update the non-root uid
 RUN chmod g=u /etc/passwd
+
+# Uninstall packages which are only required during build time
+RUN if [ "$UNINSTALL_BUILD_DEPENDENCIES" = "true" ] ; then\
+        DEBIAN_FRONTEND=noninteractive apt-mark manual libfontconfig1 && \
+        DEBIAN_FRONTEND=noninteractive apt-get remove --purge --auto-remove -q -y wget curl libgdiplus ; \
+    fi
 
 # Add the buildpack modules
 ENV PYTHONPATH "/opt/mendix/buildpack/lib/:/opt/mendix/buildpack/:/opt/mendix/buildpack/lib/python3.6/site-packages/"

--- a/README.md
+++ b/README.md
@@ -55,7 +55,8 @@ For build you can provide next arguments:
 
 - **BUILD_PATH** indicates where the application model is located. It is a root directory of an unzipped .MDA or .MPK file. In the latter case, this is the directory where your .MPR file is located. Must be within [build context](https://docs.docker.com/engine/reference/commandline/build/#extended-description). Defaults to `./project`.
 - **ROOTFS_IMAGE** is a type of rootfs image. Defaults to `mendix/rootfs:bionic`. To use Ubuntu 14.04, change this to `mendix/rootfs:trusty`. It's also possible to use a custom rootfs image as described in [Advanced feature: full-build](#advanced-feature-full-build).
-- **CF_BUILDPACK** is a version of CloudFoundry buildpack. Defaults to `v4.13.4`. For stable pipelines, it's recommended to use a fixed version from **v4.13.4** and later. CloudFoundry buildpack versions below **v4.12.0** are not supported.
+- **CF_BUILDPACK** is a version of CloudFoundry buildpack. Defaults to `v4.13.6`. For stable pipelines, it's recommended to use a fixed version from **v4.13.6** and later. CloudFoundry buildpack versions below **v4.12.0** are not supported.
+- **EXCLUDE_LOGFILTER** will exclude the `mendix-logfilter` binary from the resulting Docker image if set to `true`. Defaults to `true`. Excluding `mendix-logfilter` will reduce the image size and remove a component that's not commonly used; the `LOG_RATELIMIT` environment variable option will be disabled.
 
 ### Startup
 

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ For build you can provide next arguments:
 - **ROOTFS_IMAGE** is a type of rootfs image. Defaults to `mendix/rootfs:bionic`. To use Ubuntu 14.04, change this to `mendix/rootfs:trusty`. It's also possible to use a custom rootfs image as described in [Advanced feature: full-build](#advanced-feature-full-build).
 - **CF_BUILDPACK** is a version of CloudFoundry buildpack. Defaults to `v4.13.6`. For stable pipelines, it's recommended to use a fixed version from **v4.13.6** and later. CloudFoundry buildpack versions below **v4.12.0** are not supported.
 - **EXCLUDE_LOGFILTER** will exclude the `mendix-logfilter` binary from the resulting Docker image if set to `true`. Defaults to `true`. Excluding `mendix-logfilter` will reduce the image size and remove a component that's not commonly used; the `LOG_RATELIMIT` environment variable option will be disabled.
+- **UNINSTALL_BUILD_DEPENDENCIES** will uninstall packages which are not needed to launch an app, and are only used during the build phase. Defaults to `true`. This option will remove several libraries which are known to have unpatched CVE vulnerabilities.
 
 ### Startup
 

--- a/scripts/compilation
+++ b/scripts/compilation
@@ -46,6 +46,16 @@ def remove_jdk():
     if os.path.exists(jdk_path):
         shutil.rmtree(jdk_path, ignore_errors=False)
 
+def fix_logfilter():
+    exclude_logfilter = os.getenv("EXCLUDE_LOGFILTER", "true").lower() == "true"
+    logfilter_path = "/opt/mendix/build/bin/mendix-logfilter"
+    if os.path.exists(logfilter_path):
+        if exclude_logfilter:
+            logging.info("Removing mendix-logfilter executable")
+            os.remove(logfilter_path)
+        else:
+            os.chmod(logfilter_path, 0o0755)
+
 def make_dependencies_reusable():
     logging.info("Making dependencies reusable...")
     shutil.move("/opt/mendix/build/runtimes", "/var/mendix/build/")
@@ -67,4 +77,6 @@ if __name__ == '__main__':
     if exit_code != 0:
         sys.exit(exit_code)
     remove_jdk()
+    fix_logfilter()
     make_dependencies_reusable()
+

--- a/scripts/startup
+++ b/scripts/startup
@@ -61,6 +61,13 @@ def export_encoded_cacertificates():
         certificate_authorities = base64.b64decode(certificate_authorities_base64)
         os.environ['CERTIFICATE_AUTHORITIES'] = str(certificate_authorities,'utf-8')
 
+def check_logfilter():
+    log_ratelimit_enabled = os.getenv('LOG_RATELIMIT', None) is not None
+    logfilter_path = './bin/mendix-logfilter'
+    if log_ratelimit_enabled and not os.path.exists(logfilter_path):
+        logging.warn("LOG_RATELIMIT is set, but the mendix-logfilter binary is missing. Rebuild Docker image with EXCLUDE_LOGFILTER=false to enable log filtering")
+        del os.environ['LOG_RATELIMIT']
+
 def sigchld_handler(_signo, _stack_frame):
     # reap zombies
     logging.debug("Child process has exited, getting result")
@@ -118,6 +125,7 @@ if __name__ == '__main__':
     export_db_endpoint()
     export_vcap_variables()
     export_k8s_instance()
+    check_logfilter()
     
     export_encoded_cacertificates()
     add_uid()


### PR DESCRIPTION
To fix CVE scan scores, removed libraries which are only required during the build phase, or are a rarely used feature.
Those libraries are now opt-in to ensure they're only included when necessary.

* Exclude `mendix-logfilter` by default, since it's almost never used but lights up as a security issue. Fixed permissions for  `mendix-logfilter` since it was non-executable by default.
* Build-time dependencies such as `libgdiplus` are now uninstalled from the resulting image by default. This significantly improved the Snyk security report scores.
* Bumped up to CF Buildpack version v4.13.6 to the latest fixes