### PR TITLE
Add offline buildpack support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,8 @@ ARG DD_API_KEY
 ARG CF_BUILDPACK=v4.15.1
 # Exclude the logfilter binary by default
 ARG EXCLUDE_LOGFILTER=true
+#Add Offline buildpack support
+ARG BLOBSTORE="https://cdn.mendix.com"
 
 # Each comment corresponds to the script line:
 # 1. Create all directories needed by scripts
@@ -42,7 +44,7 @@ COPY $BUILD_PATH /opt/mendix/build
 RUN chmod +rx /opt/mendix/buildpack/bin/bootstrap-python && /opt/mendix/buildpack/bin/bootstrap-python /opt/mendix/buildpack /tmp/buildcache
 
 # Add the buildpack modules
-ENV PYTHONPATH "$PYTHONPATH:/opt/mendix/buildpack/lib/:/opt/mendix/buildpack/:/opt/mendix/buildpack/lib/python3.6/site-packages/"
+ENV PYTHONPATH "$PYTHONPATH:/opt/mendix/buildpack/lib/:/opt/mendix/buildpack/:/opt/mendix/buildpack/lib/python3.6/site-packages/" BLOBSTORE=$BLOBSTORE
 
 # Use nginx supplied by the base OS
 ENV NGINX_CUSTOM_BIN_PATH=/usr/sbin/nginx


### PR DESCRIPTION
One of our customers needed offline buildpack support. This change passes the root directory into the CF buildpack so it can run in offline mode. There is still another change needed to supply the CF Buildpack in an offline fashion (most likely via a submodel so when they pull down this repo they'll get that one as well) but we can address that one separately.