### PR TITLE
DES-2926 Offline support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,8 +14,15 @@ ARG BUILD_PATH=project
 ARG DD_API_KEY
 # CF buildpack version
 ARG CF_BUILDPACK=v4.15.1
+# CF buildpack download URL
+ARG CF_BUILDPACK_URL=https://github.com/mendix/cf-mendix-buildpack/releases/download/${CF_BUILDPACK}/cf-mendix-buildpack.zip
+
 # Exclude the logfilter binary by default
 ARG EXCLUDE_LOGFILTER=true
+
+# Allow specification of alternative BLOBSTORE location and debugging
+ARG BLOBSTORE
+ARG BUILDPACK_XTRACE
 
 # Each comment corresponds to the script line:
 # 1. Create all directories needed by scripts
@@ -25,8 +32,8 @@ ARG EXCLUDE_LOGFILTER=true
 # 5. Update ownership of /opt/mendix so that the app can run as a non-root user
 # 6. Update permissions of /opt/mendix so that the app can run as a non-root user
 RUN mkdir -p /opt/mendix/buildpack /opt/mendix/build &&\
-    echo "CF Buildpack version ${CF_BUILDPACK}" &&\
-    curl -fsSL https://github.com/mendix/cf-mendix-buildpack/releases/download/${CF_BUILDPACK}/cf-mendix-buildpack.zip -o /tmp/cf-mendix-buildpack.zip && \
+    echo "Downloading CF Buildpack from ${CF_BUILDPACK_URL}" &&\
+    curl -fsSL ${CF_BUILDPACK_URL} -o /tmp/cf-mendix-buildpack.zip && \
     python3 -m zipfile -e /tmp/cf-mendix-buildpack.zip /opt/mendix/buildpack/ &&\
     rm /tmp/cf-mendix-buildpack.zip &&\
     chgrp -R 0 /opt/mendix &&\

--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ For build you can provide next arguments:
 - **CF_BUILDPACK** is a version of CloudFoundry buildpack. Defaults to `v4.15.1`. For stable pipelines, it's recommended to use a fixed version from **v4.15.1** and later. CloudFoundry buildpack versions below **v4.15.1** are not supported.
 - **EXCLUDE_LOGFILTER** will exclude the `mendix-logfilter` binary from the resulting Docker image if set to `true`. Defaults to `true`. Excluding `mendix-logfilter` will reduce the image size and remove a component that's not commonly used; the `LOG_RATELIMIT` environment variable option will be disabled.
 - **UNINSTALL_BUILD_DEPENDENCIES** will uninstall packages which are not needed to launch an app, and are only used during the build phase. Defaults to `true`. This option will remove several libraries which are known to have unpatched CVE vulnerabilities.
+- **CF_BUILDPACK_URL** specifies the URL where the CF buildpack should be downloaded from (for example, a local mirror). Defaults to `https://github.com/mendix/cf-mendix-buildpack/releases/download/${CF_BUILDPACK}/cf-mendix-buildpack.zip`. Specifying **CF_BUILDPACK_URL** will override the version from **CF_BUILDPACK**.
+- **BLOBSTORE** can be used to specify an alternative buildpack resource server (instead of the default Mendix CDN). For more information, see the [CF Buildpack offline settings](https://github.com/mendix/cf-mendix-buildpack#offline-buildpack-settings).
 
 ### Startup
 

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ For build you can provide next arguments:
 - **UNINSTALL_BUILD_DEPENDENCIES** will uninstall packages which are not needed to launch an app, and are only used during the build phase. Defaults to `true`. This option will remove several libraries which are known to have unpatched CVE vulnerabilities.
 - **CF_BUILDPACK_URL** specifies the URL where the CF buildpack should be downloaded from (for example, a local mirror). Defaults to `https://github.com/mendix/cf-mendix-buildpack/releases/download/${CF_BUILDPACK}/cf-mendix-buildpack.zip`. Specifying **CF_BUILDPACK_URL** will override the version from **CF_BUILDPACK**.
 - **BLOBSTORE** can be used to specify an alternative buildpack resource server (instead of the default Mendix CDN). For more information, see the [CF Buildpack offline settings](https://github.com/mendix/cf-mendix-buildpack#offline-buildpack-settings).
+- **BUIDPACK_XTRACE** can be used to enable CF Buildpack [debug logging](https://github.com/mendix/cf-mendix-buildpack#logging-and-debugging). Set this variable to `true` to enable debug logging.
 
 ### Startup
 


### PR DESCRIPTION
Recreated the changes from https://github.com/mendix/docker-mendix-buildpack/pull/110.

* Allow to specify the blobstore URL (in place of cdn.mendix.com)
* Allow to specify a custom CF Buildpack download URL