### PR TITLE
Added Industrial Edge, Edge specific Configuration support

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ The container will query for a specific location, based on the environment varia
 Below an example compose file including the "IEM_CONFIG_PATH""
 
 ```
-mxpandelpad:
+myapp:
   environment:
     ADMIN_PASSWORD: *******
     DATABASE_ENDPOINT: 'jdbc:hsqldb:file:~/data/database/db:mem:mendix'

--- a/README.md
+++ b/README.md
@@ -308,8 +308,36 @@ docker build
   --build-arg BUILD_PATH=<mendix-project-location> \
   --build-arg ROOTFS_IMAGE=<root-fs-image-tag> \
   --build-arg BUILDER_ROOTFS_IMAGE=<builder-root-fs-image-tag> \
-	-t mendix/mendix-buildpack:v1.2 .
 ```
+	-t mendix/mendix-buildpack:v1.2 .
+
+
+### Industrial Edge Configuration File support
+
+When running Mendix on Industrial Edge it is possible to add a configuration file for each Edge device with specific environment variable next to the default variable which are configured within the docker compose file. 
+
+The container will query for a specific location, based on the environment variable: "IEM_CONFIG_PATH", for files with the extention ".env".  Such a file can contain 1 or more environment variable, which will be added to the environment variable of the container. This can be used to set Edge device specific Constants, Scheduled events or custom runtime settings. Check [here](https://github.com/mendix/cf-mendix-buildpack#configuring-constants) for the syntax to use. 
+
+Below an example compose file including the "IEM_CONFIG_PATH""
+
+```
+mxpandelpad:
+  environment:
+    ADMIN_PASSWORD: *******
+    DATABASE_ENDPOINT: 'jdbc:hsqldb:file:~/data/database/db:mem:mendix'
+    MXRUNTIME_DatabaseType: HSQLDB
+    MXRUNTIME_DatabaseJdbcUrl: 'jdbc:hsqldb:file:~/data/database/db:mem:mendix'
+    IEM_CONFIG_PATH: /publish
+  image: 'sample_app:1.1'
+  volumes:
+    - './publish/:/publish/'
+    - './cfg-data/:/cfg-data/'
+  mem_limit: 1gb
+  restart: unless-stopped
+  ports:
+    - '60000:8080'
+```
+
 
 ## Contributions
 

--- a/scripts/startup
+++ b/scripts/startup
@@ -41,15 +41,15 @@ def create_vcap_application():
     return vcap_application_data
 
 def export_industrial_edge_config_variable():
-    logging.debug("Executing export_industrial_edge_config_variable...")
+    logging.info("Executing export_industrial_edge_config_variable...")
 
     if 'IEM_CONFIG_FILEPATH' in os.environ:
             config_filename = os.environ.get('IEM_CONFIG_FILEPATH')
-            logging.debug("IEM Config file found: %s" % (config_filename))
+            logging.info("IEM Config file found: %s" % (config_filename))
             with open(config_filename) as config_file:
                 for line in config_file:
                     name, var = line.partition("=")[::2]
-                    logging.debug("Adding Env-variable : %s=%s" % (name.strip(), var.strip()))
+                    logging.info("Adding Env-variable : %s=%s" % (name.strip(), var.strip()))
                     os.environ[name.strip()] = var.strip()
                     
     

--- a/scripts/startup
+++ b/scripts/startup
@@ -45,11 +45,13 @@ def export_industrial_edge_config_variable():
 
     if 'IEM_CONFIG_PATH' in os.environ:
             config_path = os.environ.get('IEM_CONFIG_PATH')
+            if not config_path.endswith("/"):
+                config_path = "%s/" % (config_path)
             logging.info("IEM Config path set to: %s" % (config_path))
             for file in os.listdir(config_path):
                 if file.endswith(".env"):
                     logging.info("IEM ENV Config file found : %s" % (file))
-                    with open("%s/%s" % (config_path, file)) as config_file:
+                    with open("%s%s" % (config_path, file)) as config_file:
                         for line in config_file:
                             name, var = line.partition("=")[::2]
                             logging.info("Adding Env-variable : %s=%s" % (name.strip(), var.strip()))

--- a/scripts/startup
+++ b/scripts/startup
@@ -39,6 +39,19 @@ def create_vcap_application():
     logging.debug("Executing create_vcap_application...")
     vcap_application_data = open("vcap_application.json").read()
     return vcap_application_data
+
+def export_industrial_edge_config_variable():
+    logging.debug("Executing export_industrial_edge_config_variable...")
+
+    if 'IEM_CONFIG_FILEPATH' in os.environ:
+            config_filename = os.environ.get('IEM_CONFIG_FILEPATH')
+            logging.debug("IEM Config file found: %s" % (config_filename))
+            with open(config_filename) as config_file:
+                for line in config_file:
+                    name, var = line.partition("=")[::2]
+                    logging.debug("Adding Env-variable : %s=%s" % (name.strip(), var.strip()))
+                    os.environ[name.strip()] = var.strip()
+                    
     
 def export_k8s_instance():
     logging.debug("Checking Kubernetes environment...")
@@ -124,6 +137,7 @@ if __name__ == '__main__':
     logging.info(get_welcome_header())
     export_db_endpoint()
     export_vcap_variables()
+    export_industrial_edge_config_variable()
     export_k8s_instance()
     check_logfilter()
     

--- a/scripts/startup
+++ b/scripts/startup
@@ -43,14 +43,17 @@ def create_vcap_application():
 def export_industrial_edge_config_variable():
     logging.info("Executing export_industrial_edge_config_variable...")
 
-    if 'IEM_CONFIG_FILEPATH' in os.environ:
-            config_filename = os.environ.get('IEM_CONFIG_FILEPATH')
-            logging.info("IEM Config file found: %s" % (config_filename))
-            with open(config_filename) as config_file:
-                for line in config_file:
-                    name, var = line.partition("=")[::2]
-                    logging.info("Adding Env-variable : %s=%s" % (name.strip(), var.strip()))
-                    os.environ[name.strip()] = var.strip()
+    if 'IEM_CONFIG_PATH' in os.environ:
+            config_path = os.environ.get('IEM_CONFIG_PATH')
+            logging.info("IEM Config path set to: %s" % (config_path))
+            for file in os.listdir(config_path):
+                if file.endswith(".env"):
+                    logging.info("IEM ENV Config file found : %s" % (file))
+                    with open("%s/%s" % (config_path, file)) as config_file:
+                        for line in config_file:
+                            name, var = line.partition("=")[::2]
+                            logging.info("Adding Env-variable : %s=%s" % (name.strip(), var.strip()))
+                            os.environ[name.strip()] = var.strip()
                     
     
 def export_k8s_instance():


### PR DESCRIPTION
Dear, 

I have added the ability to load Edge specific environment variable based on an .env file which is configured for a specific Edge devices. 

This feature is essential to run Mendix on Siemens Industrial Edge. 

Kind Regards
Erno =