### PR TITLE
Changes to make this compatible for OCP 3.x w/o root priviledges

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG ROOTFS_IMAGE=mendix/rootfs:ubi8
 ARG BUILDER_ROOTFS_IMAGE=mendix/rootfs:bionic
 
 # Build stage
-FROM ${BUILDER_ROOTFS_IMAGE} AS builder
+FROM mendix/rootfs:bionic AS builder
 
 # Build-time variables
 ARG BUILD_PATH=project
@@ -76,7 +76,7 @@ RUN mkdir -p /tmp/buildcache /var/mendix/build /var/mendix/build/.local &&\
     chown -R ${USER_UID}:0 /opt/mendix /var/mendix &&\
     chmod -R g=u /opt/mendix /var/mendix
 
-FROM ${ROOTFS_IMAGE}
+FROM mendix/rootfs:ubi8
 LABEL Author="Mendix Digital Ecosystems"
 LABEL maintainer="digitalecosystems@mendix.com"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -127,7 +127,7 @@ RUN rm /run/nginx.pid || true
 
 RUN sed -i.bak 's/^user/#user/' /etc/nginx/nginx.conf && cat /etc/nginx/nginx.conf
 
-RUN apt install net-tools
+RUN yum install net-tools
 
 USER ${USER_UID}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@
 # Build stage
 FROM mendix/rootfs:bionic AS builder
 
-// move down for ocp3 (have builder first)
+# (cut) move down for ocp3 (have builder first)
 ARG ROOTFS_IMAGE=mendix/rootfs:ubi8
 ARG BUILDER_ROOTFS_IMAGE=mendix/rootfs:bionic
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -119,6 +119,7 @@ RUN mkdir -p /home/vcap /opt/datadog-agent/run &&\
 RUN chmod +rx /opt/mendix/build/startup &&\
     chown -R ${USER_UID}:0 /opt/mendix &&\
     chmod -R g=u /opt/mendix &&\
+    chmod -R g=u /usr/sbin/nginx &&\
     ln -s /opt/mendix/.java /root
 
 USER ${USER_UID}

--- a/Dockerfile
+++ b/Dockerfile
@@ -76,7 +76,7 @@ RUN mkdir -p /tmp/buildcache /var/mendix/build /var/mendix/build/.local &&\
     chown -R ${USER_UID}:0 /opt/mendix /var/mendix &&\
     chmod -R g=u /opt/mendix /var/mendix
 
-FROM mendix/rootfs:ubi8
+FROM mendix/rootfs:bionic
 LABEL Author="Mendix Digital Ecosystems"
 LABEL maintainer="digitalecosystems@mendix.com"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -121,6 +121,8 @@ RUN chmod +rx /opt/mendix/build/startup &&\
     chmod -R g=u /opt/mendix &&\
     chmod -R g=u /usr/sbin/nginx &&\
     ln -s /opt/mendix/.java /root
+    
+RUN rm /run/nginx.pid || true
 
 USER ${USER_UID}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -125,6 +125,8 @@ RUN chmod +rx /opt/mendix/build/startup &&\
     
 RUN rm /run/nginx.pid || true
 
+RUN sed -i.bak 's/^user/#user/' /etc/nginx/nginx.conf
+
 USER ${USER_UID}
 
 # Copy jre from build container

--- a/Dockerfile
+++ b/Dockerfile
@@ -125,7 +125,10 @@ RUN chmod +rx /opt/mendix/build/startup &&\
     
 RUN rm /run/nginx.pid || true
 
+# remove user forcing
 RUN sed -i.bak 's/^user/#user/' /etc/nginx/nginx.conf && cat /etc/nginx/nginx.conf
+# nginx get pid out of /run folder
+RUN sed -i.bak 's/run/tmp/' /etc/nginx/nginx.conf && cat /etc/nginx/nginx.conf
 
 RUN yum -y install net-tools
 
@@ -148,5 +151,8 @@ WORKDIR /opt/mendix/build
 # Expose nginx port
 ENV PORT 8080
 EXPOSE $PORT
+
+# port as configured in nginx
+EXPOSE 80
 
 ENTRYPOINT ["/opt/mendix/build/startup","/opt/mendix/buildpack/buildpack/start.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@
 # Author: Mendix Digital Ecosystems, digitalecosystems@mendix.com
 # Version: 2.1.0
 
-# Build stage
+# Build stage (cut) no $ and dynamic setting - hardcode 
 FROM mendix/rootfs:bionic AS builder
 
 # (cut) move down for ocp3 (have builder first)
@@ -115,22 +115,26 @@ RUN mkdir -p /home/vcap /opt/datadog-agent/run &&\
 # 1. Make the startup script executable
 # 2. Update ownership of /opt/mendix so that the app can run as a non-root user
 # 3. Update permissions of /opt/mendix so that the app can run as a non-root user
-# 4. Ensure that running Java 8 as root will still be able to load offline licenses
+# 4. Update ownership of /etc/nginx so that the app can run as a non-root user
+# 5. Update permissions of /etc/nginx so that the app can run as a non-root user
+# 6. Ensure that running Java 8 as root will still be able to load offline licenses
 RUN chmod +rx /opt/mendix/build/startup &&\
     chown -R ${USER_UID}:0 /opt/mendix &&\
-    chown -R ${USER_UID}:0 /etc/nginx &&\
     chmod -R 777 /opt/mendix &&\
+    chown -R ${USER_UID}:0 /etc/nginx &&\
     chmod -R 777 /etc/nginx &&\
     ln -s /opt/mendix/.java /root
     
+# allow non-root user to write the pid file
 RUN chown -R ${USER_UID}:0 /run/nginx.pid && chmod -R 777 /run/nginx.pid
 
-# remove user forcing
+# remove user forcing (user nginx)
 RUN sed -i.bak 's/^user/#user/' /etc/nginx/nginx.conf && cat /etc/nginx/nginx.conf
 
-# nginx get pid out of /run folder
+# fix listening - for non root port has to be > 1024 - makes it consistent with EXPOSE below
 RUN sed -i.bak 's/80/8080/' /etc/nginx/nginx.conf && cat /etc/nginx/nginx.conf
 
+# temp to diagnose nginx issues
 RUN yum -y install net-tools
 
 USER ${USER_UID}

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG ROOTFS_IMAGE=mendix/rootfs:ubi8
 ARG BUILDER_ROOTFS_IMAGE=mendix/rootfs:bionic
 
 # Build stage
-FROM mendix/rootfs:ubi8 AS builder
+FROM mendix/rootfs:bionic AS builder
 
 # Build-time variables
 ARG BUILD_PATH=project

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,11 +3,13 @@
 #
 # Author: Mendix Digital Ecosystems, digitalecosystems@mendix.com
 # Version: 2.1.0
-ARG ROOTFS_IMAGE=mendix/rootfs:ubi8
-ARG BUILDER_ROOTFS_IMAGE=mendix/rootfs:bionic
 
 # Build stage
 FROM mendix/rootfs:bionic AS builder
+
+// move down for ocp3 (have builder first)
+ARG ROOTFS_IMAGE=mendix/rootfs:ubi8
+ARG BUILDER_ROOTFS_IMAGE=mendix/rootfs:bionic
 
 # Build-time variables
 ARG BUILD_PATH=project

--- a/Dockerfile
+++ b/Dockerfile
@@ -123,12 +123,10 @@ RUN chmod +rx /opt/mendix/build/startup &&\
     chmod -R 777 /etc/nginx &&\
     ln -s /opt/mendix/.java /root
     
-RUN rm /run/nginx.pid || true
+RUN chown -R ${USER_UID}:0 /run/nginx.pid && chmod -R 777 /run/nginx.pid
 
 # remove user forcing
 RUN sed -i.bak 's/^user/#user/' /etc/nginx/nginx.conf && cat /etc/nginx/nginx.conf
-# nginx get pid out of /run folder
-RUN sed -i.bak 's/run/tmp/' /etc/nginx/nginx.conf && cat /etc/nginx/nginx.conf
 
 # nginx get pid out of /run folder
 RUN sed -i.bak 's/80/8080/' /etc/nginx/nginx.conf && cat /etc/nginx/nginx.conf

--- a/Dockerfile
+++ b/Dockerfile
@@ -125,7 +125,7 @@ RUN chmod +rx /opt/mendix/build/startup &&\
     
 RUN rm /run/nginx.pid || true
 
-RUN sed -i.bak 's/^user/#user/' /etc/nginx/nginx.conf
+RUN sed -i.bak 's/^user/#user/' /etc/nginx/nginx.conf && cat /etc/nginx/nginx.conf
 
 USER ${USER_UID}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@
 # (cut) no $ and dynamic setting - hardcode 
 FROM mendix/rootfs:bionic AS builder
 
-# (cut) move down for ocp3 (have builder first)
+# (cut) moved down for ocp3 (have builder FROM clause first)
 ARG ROOTFS_IMAGE=mendix/rootfs:ubi8
 ARG BUILDER_ROOTFS_IMAGE=mendix/rootfs:bionic
 
@@ -127,16 +127,16 @@ RUN chmod +rx /opt/mendix/build/startup &&\
     chmod -R 777 /etc/nginx &&\
     ln -s /opt/mendix/.java /root
     
-# allow non-root user to write the pid file
+# NGINX allow non-root user to write the pid file
 RUN chown -R ${USER_UID}:0 /run/nginx.pid && chmod -R 777 /run/nginx.pid
 
 # NGINX remove user forcing (user nginx)
-RUN sed -i.bak 's/^user/#user/' /etc/nginx/nginx.conf && cat /etc/nginx/nginx.conf
+RUN sed -i.bak 's/^user/#user/' /etc/nginx/nginx.conf
 
 # NGINX fix listening - for non root port has to be > 1024 - makes it consistent with EXPOSE below
-RUN sed -i.bak 's/80/8080/' /etc/nginx/nginx.conf && cat /etc/nginx/nginx.conf
+RUN sed -i.bak 's/80/8080/' /etc/nginx/nginx.conf
 
-# temp to diagnose nginx issues
+# (cut) temp to diagnose nginx issues
 RUN yum -y install net-tools
 
 USER ${USER_UID}

--- a/Dockerfile
+++ b/Dockerfile
@@ -118,8 +118,9 @@ RUN mkdir -p /home/vcap /opt/datadog-agent/run &&\
 # 4. Ensure that running Java 8 as root will still be able to load offline licenses
 RUN chmod +rx /opt/mendix/build/startup &&\
     chown -R ${USER_UID}:0 /opt/mendix &&\
-    chmod -R g=u /opt/mendix &&\
-    chmod -R g=u /usr/sbin/nginx &&\
+    chown -R ${USER_UID}:0 /etc/nginx &&\
+    chmod -R 777 /opt/mendix &&\
+    chmod -R 777 /etc/nginx &&\
     ln -s /opt/mendix/.java /root
     
 RUN rm /run/nginx.pid || true

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ARG ROOTFS_IMAGE=mendix/rootfs:ubi8
 ARG BUILDER_ROOTFS_IMAGE=mendix/rootfs:bionic
 
 # Build stage
-FROM mendix/rootfs:bionic AS builder
+FROM mendix/rootfs:ubi8 AS builder
 
 # Build-time variables
 ARG BUILD_PATH=project
@@ -76,7 +76,7 @@ RUN mkdir -p /tmp/buildcache /var/mendix/build /var/mendix/build/.local &&\
     chown -R ${USER_UID}:0 /opt/mendix /var/mendix &&\
     chmod -R g=u /opt/mendix /var/mendix
 
-FROM mendix/rootfs:bionic
+FROM mendix/rootfs:ubi8
 LABEL Author="Mendix Digital Ecosystems"
 LABEL maintainer="digitalecosystems@mendix.com"
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -127,8 +127,7 @@ RUN rm /run/nginx.pid || true
 
 RUN sed -i.bak 's/^user/#user/' /etc/nginx/nginx.conf && cat /etc/nginx/nginx.conf
 
-# makes the build hang, so no netstat
-# RUN yum install net-tools
+RUN yum -y install net-tools
 
 USER ${USER_UID}
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -130,6 +130,9 @@ RUN sed -i.bak 's/^user/#user/' /etc/nginx/nginx.conf && cat /etc/nginx/nginx.co
 # nginx get pid out of /run folder
 RUN sed -i.bak 's/run/tmp/' /etc/nginx/nginx.conf && cat /etc/nginx/nginx.conf
 
+# nginx get pid out of /run folder
+RUN sed -i.bak 's/80/8080/' /etc/nginx/nginx.conf && cat /etc/nginx/nginx.conf
+
 RUN yum -y install net-tools
 
 USER ${USER_UID}
@@ -151,8 +154,5 @@ WORKDIR /opt/mendix/build
 # Expose nginx port
 ENV PORT 8080
 EXPOSE $PORT
-
-# port as configured in nginx
-EXPOSE 80
 
 ENTRYPOINT ["/opt/mendix/build/startup","/opt/mendix/buildpack/buildpack/start.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@
 # Author: Mendix Digital Ecosystems, digitalecosystems@mendix.com
 # Version: 2.1.0
 
-# Build stage (cut) no $ and dynamic setting - hardcode 
+# Build stage 
+# (cut) no $ and dynamic setting - hardcode 
 FROM mendix/rootfs:bionic AS builder
 
 # (cut) move down for ocp3 (have builder first)
@@ -78,6 +79,7 @@ RUN mkdir -p /tmp/buildcache /var/mendix/build /var/mendix/build/.local &&\
     chown -R ${USER_UID}:0 /opt/mendix /var/mendix &&\
     chmod -R g=u /opt/mendix /var/mendix
 
+# (cut) no $ and dynamic setting - hardcode (same as above)
 FROM mendix/rootfs:ubi8
 LABEL Author="Mendix Digital Ecosystems"
 LABEL maintainer="digitalecosystems@mendix.com"
@@ -115,8 +117,8 @@ RUN mkdir -p /home/vcap /opt/datadog-agent/run &&\
 # 1. Make the startup script executable
 # 2. Update ownership of /opt/mendix so that the app can run as a non-root user
 # 3. Update permissions of /opt/mendix so that the app can run as a non-root user
-# 4. Update ownership of /etc/nginx so that the app can run as a non-root user
-# 5. Update permissions of /etc/nginx so that the app can run as a non-root user
+# 4. (cut) Update ownership of /etc/nginx so that the app can run as a non-root user
+# 5. (cut) Update permissions of /etc/nginx so that the app can run as a non-root user
 # 6. Ensure that running Java 8 as root will still be able to load offline licenses
 RUN chmod +rx /opt/mendix/build/startup &&\
     chown -R ${USER_UID}:0 /opt/mendix &&\
@@ -128,10 +130,10 @@ RUN chmod +rx /opt/mendix/build/startup &&\
 # allow non-root user to write the pid file
 RUN chown -R ${USER_UID}:0 /run/nginx.pid && chmod -R 777 /run/nginx.pid
 
-# remove user forcing (user nginx)
+# NGINX remove user forcing (user nginx)
 RUN sed -i.bak 's/^user/#user/' /etc/nginx/nginx.conf && cat /etc/nginx/nginx.conf
 
-# fix listening - for non root port has to be > 1024 - makes it consistent with EXPOSE below
+# NGINX fix listening - for non root port has to be > 1024 - makes it consistent with EXPOSE below
 RUN sed -i.bak 's/80/8080/' /etc/nginx/nginx.conf && cat /etc/nginx/nginx.conf
 
 # temp to diagnose nginx issues

--- a/Dockerfile
+++ b/Dockerfile
@@ -127,6 +127,8 @@ RUN rm /run/nginx.pid || true
 
 RUN sed -i.bak 's/^user/#user/' /etc/nginx/nginx.conf && cat /etc/nginx/nginx.conf
 
+RUN apt install net-tools
+
 USER ${USER_UID}
 
 # Copy jre from build container

--- a/Dockerfile
+++ b/Dockerfile
@@ -127,7 +127,8 @@ RUN rm /run/nginx.pid || true
 
 RUN sed -i.bak 's/^user/#user/' /etc/nginx/nginx.conf && cat /etc/nginx/nginx.conf
 
-RUN yum install net-tools
+# makes the build hang, so no netstat
+# RUN yum install net-tools
 
 USER ${USER_UID}
 


### PR DESCRIPTION
with those changes - a bundle can be deployed to an OCP 3.x (>12) instance with non -root priviledges