### PR TITLE
Use postgres instead of mysql

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,4 +29,4 @@ test-container:
 	tests/test-generic.sh tests/docker-compose-azuresql.yml
 
 run-container:
-	BUILDPACK_VERSION=$(VERSION) docker-compose -f tests/docker-compose-mysql.yml up
+	BUILDPACK_VERSION=$(VERSION) docker-compose -f tests/docker-compose-postgres.yml up


### PR DESCRIPTION
When using mysql, a flaky bug periodically occurs in related projects in the form of an error connecting to the database.

`ConnectionBus: Opening JDBC connection to Some(db:3306) failed with SQLState: 08000 Error code: -1 Message: Could not connect to address=(host=db)(port=3306)(type=master) : Socket fail to connect to host:db, port:3306. Connection refused (Connection refused) Retrying...(1/4)`

 Since the container on PostgresSql performs the same functionality, it would be good to use it as a more stable container