### PR TITLE
mxbuild requirs libicu and xargs provided by findutils package

### DIFF
--- a/rootfs-builder.dockerfile
+++ b/rootfs-builder.dockerfile
@@ -13,7 +13,7 @@ ENV LC_ALL C.UTF-8
 RUN rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm &&\
     microdnf update -y && \
     microdnf module enable nginx:1.20 -y && \
-    microdnf install -y wget curl glibc-langpack-en python3 python3-setuptools openssl libgdiplus tar gzip unzip libpq nginx nginx-mod-stream binutils fontconfig && \
+    microdnf install -y wget curl glibc-langpack-en python3 python3-setuptools openssl libgdiplus tar gzip unzip libpq nginx nginx-mod-stream binutils fontconfig libicu findutils && \
     microdnf clean all && rm -rf /var/cache/yum
 
 # Set nginx permissions


### PR DESCRIPTION
Fixes issues:

```
ERROR: MxBuild returned errors: {"errors": [{"message": "An error occurred while cleaning the deployment directory.", "details": "\n\nxargs is not available\n\n\n"}], "problems": []}
```

And

```
Process terminated. Couldn't find a valid ICU package installed on the system. Please install libicu using your package manager and try again. Alternatively you can set the configuration flag System.Globalization.Invariant to true if you want to run with no globalization support. Please see https://aka.ms/dotnet-missing-libicu for more information.
```