### PR TITLE
Add support for the latest CF Buildpack

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ FROM ${BUILDER_ROOTFS_IMAGE} AS builder
 ARG BUILD_PATH=project
 ARG DD_API_KEY
 # CF buildpack version
-ARG CF_BUILDPACK=v4.30.19
+ARG CF_BUILDPACK=v4.30.20
 # CF buildpack download URL
 ARG CF_BUILDPACK_URL=https://github.com/mendix/cf-mendix-buildpack/releases/download/${CF_BUILDPACK}/cf-mendix-buildpack.zip
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ FROM ${BUILDER_ROOTFS_IMAGE} AS builder
 ARG BUILD_PATH=project
 ARG DD_API_KEY
 # CF buildpack version
-ARG CF_BUILDPACK=v4.30.17
+ARG CF_BUILDPACK=v4.30.19
 # CF buildpack download URL
 ARG CF_BUILDPACK_URL=https://github.com/mendix/cf-mendix-buildpack/releases/download/${CF_BUILDPACK}/cf-mendix-buildpack.zip
 

--- a/rootfs-app.dockerfile
+++ b/rootfs-app.dockerfile
@@ -12,7 +12,7 @@ ENV LC_ALL C.UTF-8
 # install dependencies & remove package lists
 RUN microdnf update -y && \
     microdnf module enable nginx:1.20 -y && \
-    microdnf install -y glibc-langpack-en python3 openssl nginx nginx-mod-stream fontconfig && \
+    microdnf install -y glibc-langpack-en python36 openssl nginx nginx-mod-stream fontconfig && \
     microdnf clean all && rm -rf /var/cache/yum
 
 # Set nginx permissions

--- a/rootfs-builder.dockerfile
+++ b/rootfs-builder.dockerfile
@@ -13,7 +13,7 @@ ENV LC_ALL C.UTF-8
 RUN rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm &&\
     microdnf update -y && \
     microdnf module enable nginx:1.20 -y && \
-    microdnf install -y wget curl glibc-langpack-en python3 python3-setuptools openssl libgdiplus tar gzip unzip libpq nginx nginx-mod-stream binutils fontconfig libicu findutils && \
+    microdnf install -y wget curl glibc-langpack-en python36 python3-setuptools openssl libgdiplus tar gzip unzip libpq nginx nginx-mod-stream binutils fontconfig libicu findutils && \
     microdnf clean all && rm -rf /var/cache/yum
 
 # Set nginx permissions
@@ -22,7 +22,7 @@ RUN touch /run/nginx.pid && \
     chmod -R g=u /var/log/nginx /var/lib/nginx /run/nginx.pid
 
 # Pretend to be Ubuntu to bypass CF Buildpack's check
-RUN rm /etc/*-release && echo 'Ubuntu release 18.04 (Bionic)' > /etc/debian-release
+RUN rm /etc/*-release && printf 'NAME="Ubuntu"\nID=ubuntu\nVersion="18.04 LTS (Bionic Beaver)"\nVERSION_CODENAME=bionic\n' > /etc/os-release
 
 # Set python alias to python3 (required for Datadog)
 RUN alternatives --set python /usr/bin/python3


### PR DESCRIPTION
* Change the way the OS is identified.
* Use a fixed version of Python (3.6).