### PR TITLE
DES-5253 Fix builds

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,8 +4,6 @@
 
 The Mendix Buildpack for Docker (aka docker-mendix-buildpack) is an **example project** you can use to build and run your Mendix Application in a [Docker](https://www.docker.com/) container.
 
-**⚠️ Warning** At this time, Docker Buildpack doesn't support building Mendix 10 MPK files. To deploy a Mendix 10 app with Docker Buildpack, you will need to build the MDA file first (using Studio Pro 10 or [MxBuild](https://docs.mendix.com/refguide/mxbuild/)), and deploy the MDA file using Docker Buildpack.
-
 **⚠️ Warning** If your pipeline is based on Docker Buildpack V4 or an earlier version, see the [upgrading from Docker Buildpack v4](upgrading-from-v4.md) document. To use Docker Buildpack v5, some changes will be required in your build process.
 
 For a Kubernetes native solution to run Mendix apps, see [Mendix for Private Cloud](https://www.mendix.com/evaluation-guide/app-lifecycle/mendix-for-private-cloud/).

--- a/rootfs-app.dockerfile
+++ b/rootfs-app.dockerfile
@@ -12,7 +12,7 @@ ENV LC_ALL C.UTF-8
 # install dependencies & remove package lists
 RUN microdnf update -y && \
     microdnf module enable nginx:1.20 -y && \
-    microdnf install -y glibc-langpack-en python311 openssl nginx nginx-mod-stream java-11-openjdk-headless fontconfig && \
+    microdnf install -y glibc-langpack-en python311 openssl nginx nginx-mod-stream java-11-openjdk-headless tzdata-java fontconfig && \
     microdnf clean all && rm -rf /var/cache/yum
 
 # Set nginx permissions

--- a/rootfs-builder.dockerfile
+++ b/rootfs-builder.dockerfile
@@ -69,7 +69,7 @@ RUN mkdir -p /opt/mendix/buildpack /opt/mendix/build &&\
     chmod -R g=u /opt/mendix
 
 # Copy python scripts which execute the buildpack (exporting the VCAP variables)
-COPY scripts/compilation.py scripts/git /opt/mendix/buildpack/
+COPY scripts/compilation.py scripts/git scripts/mono-adapter /opt/mendix/buildpack/
 
 # Install the buildpack Python dependencies
 RUN PYTHON_BUILD_RPMS="python3.11-pip python3.11-devel libffi-devel gcc" && \

--- a/rootfs-builder.dockerfile
+++ b/rootfs-builder.dockerfile
@@ -10,7 +10,7 @@ ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8
 
 # CF buildpack version
-ARG CF_BUILDPACK=v5.0.0
+ARG CF_BUILDPACK=v5.0.4
 # CF buildpack download URL
 ARG CF_BUILDPACK_URL=https://github.com/mendix/cf-mendix-buildpack/releases/download/${CF_BUILDPACK}/cf-mendix-buildpack.zip
 
@@ -33,7 +33,7 @@ RUN rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.
     microdnf clean all && rm -rf /var/cache/yum
 
 # Install RHEL alternatives to CF Buildpack dependencies
-RUN microdnf install -y java-11-openjdk-headless java-11-openjdk-devel mono-core-5.20.1.34 libgdiplus0 libicu && \
+RUN microdnf install -y java-11-openjdk-headless java-11-openjdk-devel tzdata-java mono-core-5.20.1.34 libgdiplus0 libicu && \
     microdnf clean all && rm -rf /var/cache/yum
 
 # Set nginx permissions

--- a/scripts/mono-adapter
+++ b/scripts/mono-adapter
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+# This script works as a drop-in replacement for mono and allows using non-mono mxbuild in CF Buildpack.
+# It's a temporary workaround until https://github.com/mendix/cf-mendix-buildpack/pull/661 is available in CF Buildpack v5.
+
+MONO_ARGS=()
+# Rewrite the command to exclude mono and its args, only keep mxbuild
+while [[ $# -gt 0 ]]; do
+  case $1 in
+    *mxbuild.exe)
+      # Remove .exe from mxbuild executable name
+      MONO_ARGS=(${1%.*})
+      shift
+      ;;
+    *)
+      # Keep all args after mxbuild
+      if [ -n "$MONO_ARGS" ]; then
+        MONO_ARGS+=("$1")
+      fi
+      shift
+      ;;
+  esac
+done
+
+echo "Launching MxBuild through mono adapter..."
+
+exec "${MONO_ARGS[@]}"


### PR DESCRIPTION
* Add `tzdata-java` package to address https://github.com/mendix/docker-mendix-buildpack/issues/176 and https://bugzilla.redhat.com/show_bug.cgi?id=2224427
* Added an adapter to run MxBuild without Mono - to allow building Mendix 10 apps from MPK sources