### PR TITLE
Ensure that writing to /etc/passwd is no longer required

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,10 +53,6 @@ ARG USER_UID=1001
 # Set the home path
 ENV HOME=/opt/mendix/build
 
-# Allow the user group to modify /etc/passwd so that OpenShift 3 randomized UIDs are supported by CF Buildpack 
-RUN chmod g=u /etc/passwd &&\
-    chown ${USER_UID}:0 /etc/passwd
-
 # Add the buildpack modules
 ENV PYTHONPATH "/opt/mendix/buildpack/lib/:/opt/mendix/buildpack/:/opt/mendix/buildpack/lib/python3.11/site-packages/"
 

--- a/rootfs-builder.dockerfile
+++ b/rootfs-builder.dockerfile
@@ -10,7 +10,7 @@ ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8
 
 # CF buildpack version
-ARG CF_BUILDPACK=v5.0.4
+ARG CF_BUILDPACK=v5.0.9
 # CF buildpack download URL
 ARG CF_BUILDPACK_URL=https://github.com/mendix/cf-mendix-buildpack/releases/download/${CF_BUILDPACK}/cf-mendix-buildpack.zip
 

--- a/scripts/startup.py
+++ b/scripts/startup.py
@@ -5,6 +5,7 @@ import os
 import re
 import runpy
 import sys
+import pwd
 import base64
 
 logging.basicConfig(
@@ -82,6 +83,9 @@ def check_logfilter():
         logging.warn("LOG_RATELIMIT is set, but the mendix-logfilter binary is missing. Rebuild Docker image with EXCLUDE_LOGFILTER=false to enable log filtering")
         del os.environ['LOG_RATELIMIT']
 
+def emulate_getpwuid():
+    pwd.getpwuid = lambda _: ['mendix', None, os.getuid(), os.getgid(), 'mendix user', '/opt/mendix/build', '/sbin/nologin']
+
 def call_buildpack_startup():
     logging.debug("Executing call_buildpack_startup...")
 
@@ -122,6 +126,7 @@ if __name__ == '__main__':
     export_industrial_edge_config_variable()
     export_k8s_instance()
     check_logfilter()
+    emulate_getpwuid()
     
     export_encoded_cacertificates()
     call_buildpack_startup()

--- a/scripts/startup.py
+++ b/scripts/startup.py
@@ -5,7 +5,6 @@ import os
 import re
 import runpy
 import sys
-import pwd
 import base64
 
 logging.basicConfig(
@@ -83,9 +82,6 @@ def check_logfilter():
         logging.warn("LOG_RATELIMIT is set, but the mendix-logfilter binary is missing. Rebuild Docker image with EXCLUDE_LOGFILTER=false to enable log filtering")
         del os.environ['LOG_RATELIMIT']
 
-def emulate_getpwuid():
-    pwd.getpwuid = lambda _: ['mendix', None, os.getuid(), os.getgid(), 'mendix user', '/opt/mendix/build', '/sbin/nologin']
-
 def call_buildpack_startup():
     logging.debug("Executing call_buildpack_startup...")
 
@@ -126,7 +122,6 @@ if __name__ == '__main__':
     export_industrial_edge_config_variable()
     export_k8s_instance()
     check_logfilter()
-    emulate_getpwuid()
     
     export_encoded_cacertificates()
     call_buildpack_startup()


### PR DESCRIPTION
* OpenShift 4 automatically updates `/etc/passwd` for randomly generated UIDs
  * But something caused CF Buildpack's [getpwuid()](https://github.com/mendix/cf-mendix-buildpack/blob/0bed066fc4f873d0b6a6037c0b9d3e4b766bb5e2/lib/m2ee/config.py#L458) to fail, most likely something to do with UNIX permissions
  * With default, out-of-the-box permissions for `/etc/passwd`, OpenShift 4 works correctly - so removed the code to make `/etc/passwd` writable, as it's not needed anymore.
* Updated to CF Buildpack v5.0.9