### PR TITLE
Added clarification about the Python version.

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ This project is a goto reference for the following scenarios :
 * Docker 20.10 (Installation [here](https://docs.docker.com/engine/installation/))
   * Earlier Docker versions are no longer compatible because they don't support multistage builds.
     To use Docker versions below 20.10, download an earlier Mendix Docker Buildpack release, such as [v2.3.2](https://github.com/mendix/docker-mendix-buildpack/releases/tag/v2.3.2)
-* Python 3
+* Python 3.8
 * For preparing, a local installation of `curl`
 * For local testing, make sure you can run the [docker-compose command](https://docs.docker.com/compose/install/)
 * A Mendix app based on Mendix 8 or a later version


### PR DESCRIPTION
Updated readme to address https://github.com/mendix/docker-mendix-buildpack/pull/201#issuecomment-2331080904