### PR TITLE
DES-6889 Use .NET images for Mendix 9.22+.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Mendix Deployment Archive (aka mda file)
 #
 # Author: Mendix Digital Ecosystems, digitalecosystems@mendix.com
-# Version: v6.0.0
+# Version: v6.0.1
 ARG ROOTFS_IMAGE=mendix-rootfs:app
 ARG BUILDER_ROOTFS_IMAGE=mendix-rootfs:builder
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ docker push <app-root-fs-image-tag>
 
 When building the the `rootfs-builder.dockerfile` file, you can provide the following additional arguments:
 
-- **CF_BUILDPACK** is a version of CloudFoundry buildpack. Defaults to `v5.0.27`. For stable pipelines, it's recommended to use a fixed **v5.0.27** version. Other Cloud Foundry buildpacks might not work with this version of Docker Buildpack.
+- **CF_BUILDPACK** is a version of CloudFoundry buildpack. Defaults to `v5.0.26`. For stable pipelines, it's recommended to use a fixed **v5.0.26** version. Other Cloud Foundry buildpacks might not work with this version of Docker Buildpack.
 - **CF_BUILDPACK_URL** specifies the URL where the CF buildpack should be downloaded from (for example, a local mirror). Defaults to `https://github.com/mendix/cf-mendix-buildpack/releases/download/${CF_BUILDPACK}/cf-mendix-buildpack.zip`. Specifying **CF_BUILDPACK_URL** will override the version from **CF_BUILDPACK**.
 - **BUILDPACK_XTRACE** can be used to enable CF Buildpack [debug logging](https://github.com/mendix/cf-mendix-buildpack#logging-and-debugging). Set this variable to `true` to enable debug logging.
 

--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ docker push <app-root-fs-image-tag>
 
 When building the the `rootfs-builder.dockerfile` file, you can provide the following additional arguments:
 
-- **CF_BUILDPACK** is a version of CloudFoundry buildpack. Defaults to `v5.0.23`. For stable pipelines, it's recommended to use a fixed **v5.0.23** version. Other Cloud Foundry buildpacks might not work with this version of Docker Buildpack.
+- **CF_BUILDPACK** is a version of CloudFoundry buildpack. Defaults to `v5.0.27`. For stable pipelines, it's recommended to use a fixed **v5.0.27** version. Other Cloud Foundry buildpacks might not work with this version of Docker Buildpack.
 - **CF_BUILDPACK_URL** specifies the URL where the CF buildpack should be downloaded from (for example, a local mirror). Defaults to `https://github.com/mendix/cf-mendix-buildpack/releases/download/${CF_BUILDPACK}/cf-mendix-buildpack.zip`. Specifying **CF_BUILDPACK_URL** will override the version from **CF_BUILDPACK**.
 - **BUILDPACK_XTRACE** can be used to enable CF Buildpack [debug logging](https://github.com/mendix/cf-mendix-buildpack#logging-and-debugging). Set this variable to `true` to enable debug logging.
 

--- a/build.py
+++ b/build.py
@@ -167,7 +167,7 @@ def build_mpr(source_dir, mpr_file, destination, artifacts_repository=None):
     mx_version = cursor.fetchone()[0]
     mx_version_value = parse_version(mx_version)
     logging.debug('Detected Mendix version {}'.format('.'.join(map(str,mx_version_value))))
-    dotnet = 'dotnet' if mx_version_value >= (10, 0, 0, 0) else 'mono'
+    dotnet = 'dotnet' if mx_version_value >= (9, 22, 0, 0) else 'mono'
     builder_image = build_mpr_builder(mx_version, dotnet, artifacts_repository)
     model_version = None
     try:

--- a/rootfs-builder.dockerfile
+++ b/rootfs-builder.dockerfile
@@ -10,7 +10,7 @@ ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8
 
 # CF buildpack version
-ARG CF_BUILDPACK=v5.0.23
+ARG CF_BUILDPACK=v5.0.27
 # CF buildpack download URL
 ARG CF_BUILDPACK_URL=https://github.com/mendix/cf-mendix-buildpack/releases/download/${CF_BUILDPACK}/cf-mendix-buildpack.zip
 

--- a/rootfs-builder.dockerfile
+++ b/rootfs-builder.dockerfile
@@ -10,7 +10,7 @@ ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8
 
 # CF buildpack version
-ARG CF_BUILDPACK=v5.0.27
+ARG CF_BUILDPACK=v5.0.26
 # CF buildpack download URL
 ARG CF_BUILDPACK_URL=https://github.com/mendix/cf-mendix-buildpack/releases/download/${CF_BUILDPACK}/cf-mendix-buildpack.zip
 

--- a/upgrading-from-v5.md
+++ b/upgrading-from-v5.md
@@ -43,7 +43,7 @@ After the update, your pipeline might look like this:
 ```shell
 # Preparation steps
 # Downloag Docker Buildpack
-DOCKER_BUILDPACK_VERSION=v6.0.0
+DOCKER_BUILDPACK_VERSION=v6.0.1
 curl -LJ -o - https://github.com/mendix/docker-mendix-buildpack/archive/refs/tags/${DOCKER_BUILDPACK_VERSION}.tar.gz | tar --strip-components=1 -xvz
 # Checkout the Mendix app source
 git clone <mendix-app-git> mendix-app-src


### PR DESCRIPTION
This will align Docker Buildpack with the Mx4PC Tekton pipeline.

Other changes:

*  Bumped up CF Buildpack version.