### PR TITLE
override git revision with env var $MENDIX_MODEL_VERSION

### DIFF
--- a/build.py
+++ b/build.py
@@ -171,7 +171,7 @@ def build_mpr(source_dir, mpr_file, destination, artifacts_repository=None):
     builder_image = build_mpr_builder(mx_version, dotnet, artifacts_repository)
     model_version = None
     try:
-        model_version = get_git_commit(source_dir)
+        model_version = os.environ['MENDIX_MODEL_VERSION'] if 'MENDIX_MODEL_VERSION' in os.environ else get_git_commit(source_dir)
     except Exception as e:
         model_version = 'unversioned'
         logging.warning('Cannot determine git commit ({}), will set model version to unversioned'.format(e))


### PR DESCRIPTION
For us the full git hash is inconvenient as model version. We prefer abbreviated hash with the prefix "git-": `"ModelVersion": "git-59dbcaa"` To do that we want to calculate it ourselves and pass it to `build.py`. This is why we added MENDIX_MODEL_VERSION that overrides the automatic value.

Compare:
<img width="325" height="152" alt="image" src="https://github.com/user-attachments/assets/f23d4f1d-4126-48f5-8194-3726c2bdda5c" />

<img width="164" height="147" alt="image" src="https://github.com/user-attachments/assets/b0dca45d-a377-4d81-8824-78ddb87825d2" />
