### PR TITLE
Allow to supply license id and key as files

### DIFF
--- a/README.md
+++ b/README.md
@@ -229,6 +229,33 @@ docker run -it \
   mendix/mendix-buildpack:v1.2  
 ```
 
+ Instead of supplying the license id and key directly via environment variables, you could also use the alternative environment variables:
+
+* LICENSE_ID_FILE
+* LICENSE_KEY_FILE
+
+These should point to a file **INSIDE** the container holding the license id / key. 
+This allows the use of [secrets with docker-compose](https://docs.docker.com/reference/compose-file/secrets/).
+
+example:
+
+```yaml
+services:
+  app:
+    image: my-mendix-app:latest
+    secrets:
+      - license-id
+      - license-key
+    environment:
+      - LICENSE_ID_FILE=/run/secrets/license-id
+      - LICENSE_KEY_FILE=/run/secrets/license-key
+secrets:
+  license-id:
+    file: ./license-id.txt
+  license-key:
+    file: ./license-key.txt
+```
+
 ### Passing environment variables to your Mendix runtime
 
 The default values for constants will be used as defined in your project. However, you can override them with environment variables. You need to replace the dot with an underscore and prefix it with MX_. So a constant like Module. Constant with value ABC123 could be set like this:

--- a/scripts/startup.py
+++ b/scripts/startup.py
@@ -22,6 +22,22 @@ def export_db_endpoint():
             'DATABASE_ENDPOINT environment variable not found.'
             'Fallback to custom runtime variables https://github.com/mendix/cf-mendix-buildpack/#configuring-custom-runtime-settings')
             
+def export_license():
+    lic_id_path = os.getenv('LICENSE_ID_FILE')
+    if lic_id_path:
+        try:
+            with open(lic_id_path, 'r', encoding='utf-8') as f:
+                os.environ['LICENSE_ID'] = f.read().strip()
+        except Exception as e:
+            logging.warn(f"Failed to read LICENSE_ID_FILE '{lic_id_path}': {e}")
+
+    lic_key_path = os.getenv('LICENSE_KEY_FILE')
+    if lic_key_path:
+        try:
+            with open(lic_key_path, 'r', encoding='utf-8') as f:
+                os.environ['LICENSE_KEY'] = f.read().strip()
+        except Exception as e:
+            logging.warn(f"Failed to read LICENSE_KEY_FILE '{lic_key_path}': {e}")
 
 def export_vcap_variables():
     logging.debug("Executing build_vcap_variables...")
@@ -121,6 +137,7 @@ if __name__ == '__main__':
     export_vcap_variables()
     export_industrial_edge_config_variable()
     export_k8s_instance()
+    export_license()
     check_logfilter()
     
     export_encoded_cacertificates()


### PR DESCRIPTION
To support using e.g. docker compose secrets we introduce two additional environment variables that alternatively allow to supply the license id and key as file instead of as environment variable.

resolves #222