### PR TITLE
Upgraded CF Buildpack to version v5.0.30.

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ docker push <app-root-fs-image-tag>
 
 When building the the `rootfs-builder.dockerfile` file, you can provide the following additional arguments:
 
-- **CF_BUILDPACK** is a version of CloudFoundry buildpack. Defaults to `v5.0.26`. For stable pipelines, it's recommended to use a fixed **v5.0.26** version. Other Cloud Foundry buildpacks might not work with this version of Docker Buildpack.
+- **CF_BUILDPACK** is a version of CloudFoundry buildpack. Defaults to `v5.0.30`. For stable pipelines, it's recommended to use a fixed **v5.0.30** version. Other Cloud Foundry buildpacks might not work with this version of Docker Buildpack.
 - **CF_BUILDPACK_URL** specifies the URL where the CF buildpack should be downloaded from (for example, a local mirror). Defaults to `https://github.com/mendix/cf-mendix-buildpack/releases/download/${CF_BUILDPACK}/cf-mendix-buildpack.zip`. Specifying **CF_BUILDPACK_URL** will override the version from **CF_BUILDPACK**.
 - **BUILDPACK_XTRACE** can be used to enable CF Buildpack [debug logging](https://github.com/mendix/cf-mendix-buildpack#logging-and-debugging). Set this variable to `true` to enable debug logging.
 

--- a/rootfs-app.dockerfile
+++ b/rootfs-app.dockerfile
@@ -11,7 +11,7 @@ ENV LC_ALL C.UTF-8
 
 # install dependencies & remove package lists
 RUN microdnf update -y && \
-    microdnf module enable nginx:1.24 -y && \
+    microdnf module enable nginx:1.26 -y && \
     microdnf install -y glibc-langpack-en python311 openssl nginx nginx-mod-stream java-11-openjdk-headless java-17-openjdk-headless java-21-openjdk-headless tzdata-java fontconfig binutils && \
     microdnf clean all && rm -rf /var/cache/yum
 

--- a/rootfs-builder.dockerfile
+++ b/rootfs-builder.dockerfile
@@ -68,6 +68,7 @@ RUN PYTHON_BUILD_RPMS="python3.11-pip python3.11-devel libffi-devel gcc" && \
     microdnf install -y $PYTHON_BUILD_RPMS && \
     mkdir -p  /home/vcap/.local/bin/ && \
     if [ ! -f /home/vcap/.local/bin/pip ] ; then ln -s /usr/bin/pip3.11 /home/vcap/.local/bin/pip ; fi && \
+    if ! command -v pip3 ; then ln -s /usr/bin/pip3.11 /usr/bin/pip3 ; fi && \
     rm /opt/mendix/buildpack/vendor/wheels/* && \
     chmod +rx /opt/mendix/buildpack/bin/bootstrap-python && /opt/mendix/buildpack/bin/bootstrap-python /opt/mendix/buildpack /tmp/buildcache && \
     microdnf remove -y $PYTHON_BUILD_RPMS && microdnf clean all && rm -rf /var/cache/yum

--- a/rootfs-builder.dockerfile
+++ b/rootfs-builder.dockerfile
@@ -10,7 +10,7 @@ ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8
 
 # CF buildpack version
-ARG CF_BUILDPACK=v5.0.26
+ARG CF_BUILDPACK=v5.0.30
 # CF buildpack download URL
 ARG CF_BUILDPACK_URL=https://github.com/mendix/cf-mendix-buildpack/releases/download/${CF_BUILDPACK}/cf-mendix-buildpack.zip
 

--- a/rootfs-builder.dockerfile
+++ b/rootfs-builder.dockerfile
@@ -19,7 +19,7 @@ ARG BUILDPACK_XTRACE
 
 # install dependencies & remove package lists
 RUN microdnf update -y && \
-    microdnf module enable nginx:1.24 -y && \
+    microdnf module enable nginx:1.26 -y && \
     microdnf install -y wget glibc-langpack-en python311 openssl tar gzip unzip libpq nginx nginx-mod-stream binutils fontconfig findutils java-11-openjdk-headless java-17-openjdk-headless java-21-openjdk-headless && \
     microdnf remove -y /usr/bin/python && \
     microdnf clean all && rm -rf /var/cache/yum


### PR DESCRIPTION
In addition:
* switched to NGINX 1.26 as this is the latest version available in ubi9,
* added symlink from `pip3` to `pip3.11` if `pip3` is not available on the filesystem.