### PR TITLE
Upgrade cf buildpack to v5.0.33

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Mendix Deployment Archive (aka mda file)
 #
 # Author: Mendix Digital Ecosystems, digitalecosystems@mendix.com
-# Version: v6.0.3
+# Version: v6.0.4
 ARG ROOTFS_IMAGE=mendix-rootfs:app
 ARG BUILDER_ROOTFS_IMAGE=mendix-rootfs:builder
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ docker push <app-root-fs-image-tag>
 
 When building the the `rootfs-builder.dockerfile` file, you can provide the following additional arguments:
 
-- **CF_BUILDPACK** is a version of CloudFoundry buildpack. Defaults to `v5.0.32`. For stable pipelines, it's recommended to use a fixed **v5.0.31** version. Other Cloud Foundry buildpacks might not work with this version of Docker Buildpack.
+- **CF_BUILDPACK** is a version of CloudFoundry buildpack. Defaults to `v5.0.33`. For stable pipelines, it's recommended to use a fixed **v5.0.31** version. Other Cloud Foundry buildpacks might not work with this version of Docker Buildpack.
 - **CF_BUILDPACK_URL** specifies the URL where the CF buildpack should be downloaded from (for example, a local mirror). Defaults to `https://github.com/mendix/cf-mendix-buildpack/releases/download/${CF_BUILDPACK}/cf-mendix-buildpack.zip`. Specifying **CF_BUILDPACK_URL** will override the version from **CF_BUILDPACK**.
 - **BUILDPACK_XTRACE** can be used to enable CF Buildpack [debug logging](https://github.com/mendix/cf-mendix-buildpack#logging-and-debugging). Set this variable to `true` to enable debug logging.
 

--- a/rootfs-app.dockerfile
+++ b/rootfs-app.dockerfile
@@ -1,6 +1,6 @@
 # Dockerfile to create a Mendix Docker image based on either the source code or
 # Mendix Deployment Archive (aka mda file)
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9-minimal:latest
 #This version does a full build originating from the Ubuntu Docker images
 LABEL Author="Mendix Digital Ecosystems"
 LABEL maintainer="digitalecosystems@mendix.com"

--- a/rootfs-builder.dockerfile
+++ b/rootfs-builder.dockerfile
@@ -1,6 +1,6 @@
 # Dockerfile to create a Mendix Docker image based on either the source code or
 # Mendix Deployment Archive (aka mda file)
-FROM registry.access.redhat.com/ubi9/ubi-minimal:latest
+FROM registry.access.redhat.com/ubi9-minimal:latest
 #This version does a full build originating from the Ubuntu Docker images
 LABEL Author="Mendix Digital Ecosystems"
 LABEL maintainer="digitalecosystems@mendix.com"

--- a/rootfs-builder.dockerfile
+++ b/rootfs-builder.dockerfile
@@ -10,7 +10,7 @@ ENV LANG C.UTF-8
 ENV LC_ALL C.UTF-8
 
 # CF buildpack version
-ARG CF_BUILDPACK=v5.0.32
+ARG CF_BUILDPACK=v5.0.33
 # CF buildpack download URL
 ARG CF_BUILDPACK_URL=https://github.com/mendix/cf-mendix-buildpack/releases/download/${CF_BUILDPACK}/cf-mendix-buildpack.zip
 

--- a/upgrading-from-v5.md
+++ b/upgrading-from-v5.md
@@ -43,7 +43,7 @@ After the update, your pipeline might look like this:
 ```shell
 # Preparation steps
 # Downloag Docker Buildpack
-DOCKER_BUILDPACK_VERSION=v6.0.3
+DOCKER_BUILDPACK_VERSION=v6.0.4
 curl -LJ -o - https://github.com/mendix/docker-mendix-buildpack/archive/refs/tags/${DOCKER_BUILDPACK_VERSION}.tar.gz | tar --strip-components=1 -xvz
 # Checkout the Mendix app source
 git clone <mendix-app-git> mendix-app-src


### PR DESCRIPTION
Upgrade cf buildpack to v5.0.33. Also the Redhat changed the UBI image endpoint from [ubi9/ubi-minimal:latest](http://registry.access.redhat.com/ubi9/ubi-minimal:latest) to [ubi9-minimal:latest](http://registry.access.redhat.com/ubi9-minimal:latest). Check https://catalog.redhat.com/en/software/containers/ubi9-minimal/61832888c0d15aff4912fe0d#get-this-image